### PR TITLE
Add web-fetch to add-benefit workflow for live URL verification

### DIFF
--- a/.github/workflows/add-benefit.lock.yml
+++ b/.github/workflows/add-benefit.lock.yml
@@ -25,7 +25,7 @@
 # validates the benefit, checks for duplicates against benefits.json,
 # and creates a PR with the new entry if valid.
 #
-# frontmatter-hash: 4813314bf151897aa3e36597ff95b8f5193a80d0019d5bcc716ca971ee364cfc
+# frontmatter-hash: 0ebb82d9bf6d0c244ba3a83def09faa83c942c848d03627f441aa2cbc03aef4e
 
 name: "Add Benefit from Issue"
 "on":

--- a/.github/workflows/add-benefit.md
+++ b/.github/workflows/add-benefit.md
@@ -25,6 +25,7 @@ safe-outputs:
 tools:
   github:
     toolsets: [issues, repos]
+  web-fetch:
   edit:
 
 timeout-minutes: 10
@@ -68,7 +69,9 @@ Then stop — do not create a PR.
 
 ## Step 3: Validate the benefit
 
-Determine whether this is a real student discount or free-access program. Use your knowledge of the product/service. Only accept if you are confident the program exists.
+Determine whether this is a real student discount or free-access program. Use web-fetch to search for and verify the student program page — do not rely solely on your training data, as programs may have launched or changed recently. Search for "{product name} student discount" or "{product name} higher education" and fetch the most relevant result to confirm the program exists and get the correct signup URL.
+
+Only reject if you are confident no student program exists after attempting to verify online.
 
 If invalid, comment on the issue:
 > **Cannot add this benefit:**


### PR DESCRIPTION
## Summary

- Add `web-fetch:` tool to the `add-benefit` workflow
- Update Step 3 to instruct the agent to fetch live pages before rejecting a submission, rather than relying solely on training data

## Why

The agent incorrectly rejected Google Colab (issue #8) because it didn't know about the free Colab Pro for students program announced July 2025. With web-fetch, it can verify current program availability directly.

## Test plan

- [x] `gh aw compile` succeeds with 0 errors
- [ ] Re-trigger issue #8 to confirm Google Colab is now accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)