### PR TITLE
Force Tavily search in validation; slim down issue comments

### DIFF
--- a/.github/workflows/add-benefit.md
+++ b/.github/workflows/add-benefit.md
@@ -81,9 +81,7 @@ Read `benefits.json` from the repository. Check for duplicates by:
 2. **Domain match**: Does any existing benefit link share the same hostname (ignoring `www.`)?
 
 If the submission is a duplicate, comment on the issue:
-> **Duplicate detected:** This appears to be the same as **{existing benefit name}** already in our directory.
->
-> If you believe this is different, please provide more details.
+> **Duplicate:** Already in the directory as **{existing benefit name}**. If this is different, add more details.
 
 Then stop — do not create a PR.
 
@@ -91,16 +89,12 @@ Then stop — do not create a PR.
 
 Determine whether this is a real student discount or free-access program. Do not rely solely on your training data, as programs may have launched or changed recently.
 
-Use the Tavily `search` tool to search for "{product name} student discount" or "{product name} higher education free". Then use `web-fetch` to open the most relevant result and confirm the program exists and get the correct signup URL.
+**You must call the Tavily `search` tool** (not `web-fetch` on a search URL) with a query like "{product name} student discount" or "{product name} higher education free". Then use `web-fetch` to open the most relevant result and confirm the program exists and get the correct signup URL. Do not skip this step or substitute it with a Google search URL fetch.
 
-Only reject if you are confident no student program exists after attempting to verify online.
+Only reject if after using Tavily search and fetching the top results you are confident no student program exists.
 
 If invalid, comment on the issue:
-> **Cannot add this benefit:**
->
-> {reason — e.g. no known student program, unclear what product is meant}
->
-> Please provide more details or submit a different benefit.
+> **Cannot add:** {reason — e.g. no known student program, unclear what product is meant}
 
 Then stop — do not create a PR.
 
@@ -166,15 +160,7 @@ Create a PR with the changes. Use this format:
 After creating the PR, add a comment on issue #${{ github.event.issue.number }}:
 
 ```
-PR created to add **{name}**!
+Added **{name}** ({category}) — {description}
 
-| Field | Value |
-|-------|-------|
-| Category | {category} |
-| Link | {link} |
-| Tags | {tags, comma-separated} |
-
-> {description}
-
-The PR will be reviewed and merged shortly.
+PR: {pr_url}
 ```


### PR DESCRIPTION
## Summary

- **Step 3**: Explicitly require the Tavily `search` tool — the agent was calling `web_fetch` on a Google search URL instead, which returns useless rendered HTML
- **Comments**: Trim success/rejection/duplicate templates from multi-line blocks to concise one-liners

## Test plan

- [x] `gh aw compile` succeeds with 0 errors
- [ ] Re-trigger issue #8 to confirm Tavily is called and Google Colab is found

🤖 Generated with [Claude Code](https://claude.com/claude-code)