### PR TITLE
Fix: Closes keyword must be plain text in PR body

### DIFF
--- a/.github/workflows/add-benefit.md
+++ b/.github/workflows/add-benefit.md
@@ -161,7 +161,7 @@ Create a PR with the changes. Use this format:
 
 - **Title**: `Add benefit: {name}` (the safe-output title-prefix handles the prefix, so just use the benefit name)
 - **Branch**: `add-benefit-{id}`
-- **Body**:
+- **Body** (plain text, no code fences):
   ```
   ## {name}
 
@@ -173,6 +173,7 @@ Create a PR with the changes. Use this format:
   ---
   Closes #{issue_number}
   ```
+  Important: the `Closes #N` line must be plain text — not wrapped in backticks — so GitHub links and closes the issue on merge.
 
 ## Step 7: Comment on the issue
 


### PR DESCRIPTION
## Summary

The agent was generating `` `Closes #N` `` (in backticks) in the PR body, which GitHub doesn't recognize as a closing keyword. Added an explicit note to the Step 6 instructions.

Also manually closed issue #21 which was left open after PR #22 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)