### PR TITLE
Auto-close issues when duplicate or invalid

### DIFF
--- a/.github/workflows/add-benefit.lock.yml
+++ b/.github/workflows/add-benefit.lock.yml
@@ -25,7 +25,7 @@
 # validates the benefit, checks for duplicates against benefits.json,
 # and creates a PR with the new entry if valid.
 #
-# frontmatter-hash: cb548f754094666f1d97172509f5c9708f836ebf599b316f8301ee01c51db4dd
+# frontmatter-hash: 0c08915de2a4e1de449503707f3588ee1cd8e252063f8a756e7636416eeb81fe
 
 name: "Add Benefit from Issue"
 "on":
@@ -48,7 +48,7 @@ jobs:
     if: >
       (needs.pre_activation.outputs.activated == 'true') && ((github.event_name != 'issues') || ((github.event.action != 'labeled') ||
       (github.event.label.name == 'new-benefit')))
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       issues: write
@@ -84,7 +84,7 @@ jobs:
 
   agent:
     needs: activation
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     permissions: read-all
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -216,10 +216,34 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":1},"create_pull_request":{},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"add_comment":{"max":1},"close_issue":{"max":1},"create_pull_request":{},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
+            {
+              "description": "Close a GitHub issue with a closing comment. You can and should always add a comment when closing an issue to explain the action or provide context. This tool is ONLY for closing issues - use update_issue if you need to change the title, body, labels, or other metadata without closing. Use close_issue when work is complete, the issue is no longer relevant, or it's a duplicate. The closing comment should explain the resolution or reason for closing. If the issue is already closed, a comment will still be posted. CONSTRAINTS: Maximum 1 issue(s) can be closed.",
+              "inputSchema": {
+                "additionalProperties": false,
+                "properties": {
+                  "body": {
+                    "description": "Closing comment explaining why the issue is being closed and summarizing any resolution, workaround, or conclusion.",
+                    "type": "string"
+                  },
+                  "issue_number": {
+                    "description": "Issue number to close. This is the numeric ID from the GitHub URL (e.g., 901 in github.com/owner/repo/issues/901). If omitted, closes the issue that triggered this workflow (requires an issue event trigger).",
+                    "type": [
+                      "number",
+                      "string"
+                    ]
+                  }
+                },
+                "required": [
+                  "body"
+                ],
+                "type": "object"
+              },
+              "name": "close_issue"
+            },
             {
               "description": "Add a comment to an existing GitHub issue, pull request, or discussion. Use this to provide feedback, answer questions, or add information to an existing conversation. For creating new items, use create_issue, create_discussion, or create_pull_request instead. IMPORTANT: Comments are subject to validation constraints enforced by the MCP server - maximum 65536 characters for the complete comment (including footer which is added automatically), 10 mentions (@username), and 50 links. Exceeding these limits will result in an immediate error with specific guidance. CONSTRAINTS: Maximum 1 comment(s) can be added.",
               "inputSchema": {
@@ -358,6 +382,20 @@ jobs:
                 },
                 "item_number": {
                   "issueOrPRNumber": true
+                }
+              }
+            },
+            "close_issue": {
+              "defaultMax": 1,
+              "fields": {
+                "body": {
+                  "required": true,
+                  "type": "string",
+                  "sanitize": true,
+                  "maxLength": 65000
+                },
+                "issue_number": {
+                  "optionalPositiveInteger": true
                 }
               }
             },
@@ -844,7 +882,7 @@ jobs:
       - safe_outputs
       - unlock
     if: (always()) && (needs.agent.result != 'skipped')
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     permissions:
       contents: write
       discussions: write
@@ -950,7 +988,7 @@ jobs:
   detection:
     needs: agent
     if: needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     permissions: {}
     timeout-minutes: 10
     outputs:
@@ -1047,7 +1085,7 @@ jobs:
 
   pre_activation:
     if: (github.event_name != 'issues') || ((github.event.action != 'labeled') || (github.event.label.name == 'new-benefit'))
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
     steps:
@@ -1075,7 +1113,7 @@ jobs:
       - detection
       - unlock
     if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (needs.detection.outputs.success == 'true')
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     permissions:
       contents: write
       discussions: write
@@ -1139,7 +1177,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_pull_request\":{\"base_branch\":\"${{ github.ref_name }}\",\"labels\":[\"new-benefit\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"Add benefit: \"},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"close_issue\":{\"max\":1},\"create_pull_request\":{\"base_branch\":\"${{ github.ref_name }}\",\"labels\":[\"new-benefit\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"Add benefit: \"},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1154,7 +1192,7 @@ jobs:
       - agent
       - detection
     if: always()
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     permissions:
       issues: write
     timeout-minutes: 5

--- a/.github/workflows/add-benefit.md
+++ b/.github/workflows/add-benefit.md
@@ -23,6 +23,7 @@ safe-outputs:
     title-prefix: "Add benefit: "
     labels: [new-benefit]
   add-comment:
+  close-issue:
 
 mcp-servers:
   tavily:
@@ -82,7 +83,7 @@ Read `benefits.json` from the repository. Check for duplicates by:
 If the submission is a duplicate, comment on the issue:
 > **Duplicate:** Already in the directory as **{existing benefit name}**. If this is different, add more details.
 
-Then stop — do not create a PR.
+Then close the issue and stop — do not create a PR.
 
 ## Step 3: Validate the benefit
 
@@ -95,7 +96,7 @@ Only reject if after using Tavily search and fetching the top results you are co
 If invalid, comment on the issue:
 > **Cannot add:** {reason — e.g. no known student program, unclear what product is meant}
 
-Then stop — do not create a PR.
+Then close the issue and stop — do not create a PR.
 
 ## Step 4: Generate the benefit entry
 


### PR DESCRIPTION
## Summary

- Adds `close-issue` to `safe-outputs` so Grant is permitted to close issues
- Updates Step 2 (duplicate) and Step 3 (invalid) instructions to close the issue after commenting

This means submitters get clear signal that their submission was reviewed and won't linger as open issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)