### PR TITLE
Fix: rewrite PR body instructions to prevent backtick wrapping

### DIFF
--- a/.github/workflows/add-benefit.md
+++ b/.github/workflows/add-benefit.md
@@ -161,19 +161,13 @@ Create a PR with the changes. Use this format:
 
 - **Title**: `Add benefit: {name}` (the safe-output title-prefix handles the prefix, so just use the benefit name)
 - **Branch**: `add-benefit-{id}`
-- **Body** (plain text, no code fences):
-  ```
-  ## {name}
-
-  **Category:** {category}
-  **Link:** {link}
-
-  {description}
-
-  ---
-  Closes #{issue_number}
-  ```
-  Important: the `Closes #N` line must be plain text — not wrapped in backticks — so GitHub links and closes the issue on merge.
+- **Body**: the body must contain these lines in order, as plain prose (no wrapping code fences around the body):
+  - A heading: `## {name}`
+  - `**Category:** {category}`
+  - `**Link:** {link}`
+  - A blank line, then the description
+  - A horizontal rule `---`
+  - The literal text `Closes #{issue_number}` — this must appear as plain text (not inside backticks, not inside a code block) so GitHub automatically closes the issue when the PR merges
 
 ## Step 7: Comment on the issue
 


### PR DESCRIPTION
The agent consistently wraps the PR body (including the Closes keyword) in backticks when the template is shown inside a code fence. Rewrote the instruction as a field-by-field description with an explicit note about plain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)