### PR TITLE
Add PR preview deployments via gh-pages subpath

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,28 +6,48 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
+# Share the concurrency group with pr-preview so gh-pages writes never conflict
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  group: gh-pages
+  cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-24.04-arm
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/configure-pages@v4
+      - name: Push site to gh-pages root
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: .
+          if git ls-remote --exit-code origin gh-pages > /dev/null 2>&1; then
+            git fetch origin gh-pages:gh-pages
+            git worktree add /tmp/gh-pages gh-pages
+          else
+            # First deploy — create an orphan gh-pages branch
+            git worktree add /tmp/gh-pages HEAD
+            cd /tmp/gh-pages
+            git switch --orphan gh-pages
+            git rm -rf . 2>/dev/null || true
+            cd -
+          fi
 
-      - uses: actions/deploy-pages@v4
-        id: deployment
+          cd /tmp/gh-pages
+
+          # Remove root-level files but preserve pr-* preview directories
+          find . -maxdepth 1 ! -name '.' ! -name '.git' ! -name 'pr-*' -exec rm -rf {} +
+
+          cp "$GITHUB_WORKSPACE/index.html" .
+          cp "$GITHUB_WORKSPACE/benefits.json" .
+          cp "$GITHUB_WORKSPACE/categories.json" .
+          cp -r "$GITHUB_WORKSPACE/public" .
+          touch .nojekyll
+
+          git add -A
+          git diff --cached --quiet && echo "No changes to deploy" && exit 0
+          git commit -m "Deploy ${GITHUB_SHA::7} from main"
+          git push origin gh-pages

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,130 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+# Serialize all gh-pages writes to prevent push conflicts
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push preview to gh-pages/pr-${{ github.event.pull_request.number }}
+        run: |
+          PR=${{ github.event.pull_request.number }}
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # gh-pages must exist before previews can be deployed
+          if ! git ls-remote --exit-code origin gh-pages > /dev/null 2>&1; then
+            echo "gh-pages branch does not exist yet — deploy from main first"
+            exit 0
+          fi
+
+          git fetch origin gh-pages:gh-pages
+          git worktree add /tmp/gh-pages gh-pages
+
+          rm -rf /tmp/gh-pages/pr-${PR}
+          mkdir -p /tmp/gh-pages/pr-${PR}
+          cp index.html benefits.json categories.json /tmp/gh-pages/pr-${PR}/
+          cp -r public /tmp/gh-pages/pr-${PR}/
+
+          cd /tmp/gh-pages
+          git add pr-${PR}
+          git diff --cached --quiet && exit 0
+          git commit -m "Preview PR #${PR} @ ${{ github.event.pull_request.head.sha }}"
+          git push origin gh-pages
+
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request.number;
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const url = `https://student-benefits.github.io/pr-${pr}/`;
+            const marker = `<!-- pr-preview-${pr} -->`;
+            const body = `${marker}\n🔍 **Preview:** ${url}\n\n_Updated: \`${sha}\`_`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body,
+              });
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove preview from gh-pages
+        run: |
+          PR=${{ github.event.pull_request.number }}
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git ls-remote --exit-code origin gh-pages > /dev/null 2>&1 || exit 0
+
+          git fetch origin gh-pages:gh-pages
+          git worktree add /tmp/gh-pages gh-pages
+
+          cd /tmp/gh-pages
+          [ -d "pr-${PR}" ] || exit 0
+
+          git rm -rf pr-${PR}
+          git commit -m "Remove preview for PR #${PR}"
+          git push origin gh-pages
+
+      - name: Delete preview comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request.number;
+            const marker = `<!-- pr-preview-${pr} -->`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+              });
+            }


### PR DESCRIPTION
## Summary

- **`deploy.yml`**: Switched from the artifact API (`actions/deploy-pages`) to pushing directly to a `gh-pages` branch. On each deploy, root-level files are replaced but `pr-*` subdirectories are preserved, so live previews survive production deploys.
- **`pr-preview.yml`** (new): On PR open/sync, copies the site to `gh-pages/pr-{N}/` and posts a comment with the preview URL. On PR close, removes the directory and deletes the comment.
- Both workflows share `concurrency: group: gh-pages` so gh-pages pushes never race.

## Required manual step after merge

Switch the Pages source in **repo Settings → Pages → Build and deployment → Source**:

> Change from **"GitHub Actions"** to **"Deploy from a branch"**
> Branch: `gh-pages` / Folder: `/`

The first push to `main` after merging will create the `gh-pages` branch. Change the Pages source after that push completes.

## How previews work

1. Open or push to a PR
2. Workflow copies `index.html`, `benefits.json`, `categories.json`, `public/` to `gh-pages/pr-{N}/`
3. Bot comments: `https://student-benefits.github.io/pr-{N}/`
4. On PR close, the directory and comment are removed

## Limitations

- `href="/agent/"` in the Grant badge resolves to the main site (not the preview subpath) — acceptable since it's an attribution link, not part of the review surface
- First preview on a PR won't deploy if `gh-pages` doesn't exist yet (exits 0 with a message); this only affects the very first PR after merging before main has been deployed once

## Test plan

- [ ] Push to `main` creates/updates `gh-pages` branch root
- [ ] Open a PR → preview comment appears with correct URL
- [ ] Push another commit to the PR → comment updates with new SHA
- [ ] Preview URL loads the site correctly
- [ ] Merge/close the PR → `pr-{N}/` directory removed, comment deleted
- [ ] Concurrent PR pushes queue correctly (no push conflict errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)