### PR TITLE
Add purge-deployments to Makefile, run on deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help deploy purge-runs review
+.PHONY: help deploy purge-runs purge-deployments review
 
 help:
 	@echo ""
@@ -9,10 +9,11 @@ help:
 	@echo "  \033[36mreview\033[0m       Run Claude review on a PR: make review PR=<number>"
 	@echo ""
 	@echo "\033[2mMaintenance\033[0m"
-	@echo "  \033[36mpurge-runs\033[0m   Delete all completed workflow run history"
+	@echo "  \033[36mpurge-runs\033[0m         Delete all completed workflow run history"
+	@echo "  \033[36mpurge-deployments\033[0m  Delete all deployment history"
 	@echo ""
 
-deploy: purge-runs
+deploy: purge-runs purge-deployments
 	gh workflow run deploy.yml
 
 review:
@@ -24,4 +25,12 @@ purge-runs:
 		--jq '.[] | select(.status != "in_progress") | .databaseId' | \
 		while read -r id; do \
 			gh run delete $$id; \
+		done
+
+purge-deployments:
+	@REPO=$$(gh repo view --json nameWithOwner -q .nameWithOwner); \
+		gh api "/repos/$$REPO/deployments" --paginate -q '.[].id' | \
+		while read -r id; do \
+			gh api -X POST "/repos/$$REPO/deployments/$$id/statuses" -f state=inactive --silent; \
+			gh api -X DELETE "/repos/$$REPO/deployments/$$id" --silent && echo "Deleted deployment $$id"; \
 		done


### PR DESCRIPTION
## Summary

- New `purge-deployments` target: marks all deployments inactive then deletes them via the GitHub Deployments API
- `deploy` now depends on both `purge-runs` and `purge-deployments`, so both histories are cleared before each deploy

## Test plan

- [ ] `make purge-deployments` runs without error when no deployments exist
- [ ] `make purge-deployments` deletes all deployments when they exist
- [ ] `make deploy` clears both run and deployment history before triggering the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)