### PR TITLE
Fix naming, routing, and maintain-benefits automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-broken.yml
+++ b/.github/ISSUE_TEMPLATE/report-broken.yml
@@ -1,7 +1,7 @@
 name: Report Broken or Changed Benefit
 description: Report a benefit that has a broken link, changed terms, or no longer exists
 title: "[Report]: "
-labels: ["report", "needs-review"]
+labels: ["link-health", "needs-review"]
 body:
   - type: input
     id: benefit

--- a/.github/workflows/add-benefit.lock.yml
+++ b/.github/workflows/add-benefit.lock.yml
@@ -25,9 +25,9 @@
 # validates the benefit, checks for duplicates against benefits.json,
 # and creates a PR with the new entry if valid.
 #
-# frontmatter-hash: e76b2732d31f70168df6e7bb1b4063b33d96614e6043a7495a9b28b409a04cd5
+# frontmatter-hash: 4b62fa4605cb0cf048de6c9338f3300f10997004bbc61c55eaa869670c3a12c8
 
-name: "Add Benefit from Issue"
+name: "Add Benefit"
 "on":
   issues:
     # lock-for-agent: true # Lock-for-agent processed as issue locking in activation job
@@ -40,7 +40,7 @@ permissions: {}
 concurrency:
   group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number }}"
 
-run-name: "Add Benefit from Issue"
+run-name: "Add Benefit"
 
 jobs:
   activation:
@@ -158,7 +158,7 @@ jobs:
               version: "",
               agent_version: "0.0.410",
               cli_version: "v0.45.0",
-              workflow_name: "Add Benefit from Issue",
+              workflow_name: "Add Benefit",
               experimental: false,
               supports_tools_allowlist: true,
               supports_http_transport: true,
@@ -266,7 +266,7 @@ jobs:
               "name": "add_comment"
             },
             {
-              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"Add benefit: \". Labels [new-benefit] will be automatically added.",
+              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"Add Benefit: \". Labels [new-benefit] will be automatically added.",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -914,7 +914,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: 1
-          GH_AW_WORKFLOW_NAME: "Add Benefit from Issue"
+          GH_AW_WORKFLOW_NAME: "Add Benefit"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -927,7 +927,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Add Benefit from Issue"
+          GH_AW_WORKFLOW_NAME: "Add Benefit"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -940,7 +940,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Add Benefit from Issue"
+          GH_AW_WORKFLOW_NAME: "Add Benefit"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_WORKFLOW_ID: "add-benefit"
@@ -958,7 +958,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Add Benefit from Issue"
+          GH_AW_WORKFLOW_NAME: "Add Benefit"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
@@ -975,7 +975,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Add Benefit from Issue"
+          GH_AW_WORKFLOW_NAME: "Add Benefit"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1018,7 +1018,7 @@ jobs:
       - name: Setup threat detection
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "Add Benefit from Issue"
+          WORKFLOW_NAME: "Add Benefit"
           WORKFLOW_DESCRIPTION: "Processes new student benefit submissions from issues. Reads the issue,\nvalidates the benefit, checks for duplicates against benefits.json,\nand creates a PR with the new entry if valid."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
@@ -1124,7 +1124,7 @@ jobs:
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: "claude-sonnet-4"
       GH_AW_WORKFLOW_ID: "add-benefit"
-      GH_AW_WORKFLOW_NAME: "Add Benefit from Issue"
+      GH_AW_WORKFLOW_NAME: "Add Benefit"
     outputs:
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
@@ -1177,7 +1177,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"close_issue\":{\"max\":1},\"create_pull_request\":{\"base_branch\":\"${{ github.ref_name }}\",\"labels\":[\"new-benefit\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"Add benefit: \"},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"close_issue\":{\"max\":1},\"create_pull_request\":{\"base_branch\":\"${{ github.ref_name }}\",\"labels\":[\"new-benefit\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"Add Benefit: \"},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/add-benefit.md
+++ b/.github/workflows/add-benefit.md
@@ -1,4 +1,5 @@
 ---
+name: Add Benefit
 description: |
   Processes new student benefit submissions from issues. Reads the issue,
   validates the benefit, checks for duplicates against benefits.json,
@@ -20,7 +21,7 @@ permissions: read-all
 
 safe-outputs:
   create-pull-request:
-    title-prefix: "Add benefit: "
+    title-prefix: "Add Benefit: "
     labels: [new-benefit]
   add-comment:
   close-issue:

--- a/.github/workflows/discover-benefits.lock.yml
+++ b/.github/workflows/discover-benefits.lock.yml
@@ -21,17 +21,19 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Proactively discovers new student benefits not yet in the directory.
-# Searches the web for popular student discounts, filters against existing
-# entries and previously-rejected programs, and creates issues for the best
-# new discoveries (max 5 per run).
+# Proactively discovers new student benefits not yet in the directory. First
+# checks curated aggregator and program pages directly, then runs keyword
+# searches for unknown vendors. Filters against existing entries and
+# previously-rejected programs, and creates issues for the best new
+# discoveries (max 5 per run).
 #
-# frontmatter-hash: 25c955fdba3cb8cd950413a50a5534fe5f471d222ce3d678736c22551f37d42e
+# frontmatter-hash: 6cbefe60f3cbd36bcf278041c0fa46f9a3306f7f46834e1b8d639aac8aa1c0a3
 
-name: "Discover New Student Benefits"
+name: "Discover Student Benefits"
 "on":
   schedule:
-  - cron: "0 9 * * 1"
+  - cron: "32 22 * * 1"
+    # Friendly format: weekly on monday (scattered)
   workflow_dispatch:
 
 permissions: {}
@@ -39,7 +41,7 @@ permissions: {}
 concurrency:
   group: "gh-aw-${{ github.workflow }}"
 
-run-name: "Discover New Student Benefits"
+run-name: "Discover Student Benefits"
 
 jobs:
   activation:
@@ -143,7 +145,7 @@ jobs:
               version: "",
               agent_version: "0.0.410",
               cli_version: "v0.45.0",
-              workflow_name: "Discover New Student Benefits",
+              workflow_name: "Discover Student Benefits",
               experimental: false,
               supports_tools_allowlist: true,
               supports_http_transport: true,
@@ -833,7 +835,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: 1
-          GH_AW_WORKFLOW_NAME: "Discover New Student Benefits"
+          GH_AW_WORKFLOW_NAME: "Discover Student Benefits"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -846,7 +848,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Discover New Student Benefits"
+          GH_AW_WORKFLOW_NAME: "Discover Student Benefits"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -859,7 +861,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Discover New Student Benefits"
+          GH_AW_WORKFLOW_NAME: "Discover Student Benefits"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_WORKFLOW_ID: "discover-benefits"
@@ -877,7 +879,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Discover New Student Benefits"
+          GH_AW_WORKFLOW_NAME: "Discover Student Benefits"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
@@ -925,8 +927,8 @@ jobs:
       - name: Setup threat detection
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "Discover New Student Benefits"
-          WORKFLOW_DESCRIPTION: "Proactively discovers new student benefits not yet in the directory.\nSearches the web for popular student discounts, filters against existing\nentries and previously-rejected programs, and creates issues for the best\nnew discoveries (max 5 per run)."
+          WORKFLOW_NAME: "Discover Student Benefits"
+          WORKFLOW_DESCRIPTION: "Proactively discovers new student benefits not yet in the directory. First\nchecks curated aggregator and program pages directly, then runs keyword\nsearches for unknown vendors. Filters against existing entries and\npreviously-rejected programs, and creates issues for the best new\ndiscoveries (max 5 per run)."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1004,7 +1006,7 @@ jobs:
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: "claude-sonnet-4"
       GH_AW_WORKFLOW_ID: "discover-benefits"
-      GH_AW_WORKFLOW_NAME: "Discover New Student Benefits"
+      GH_AW_WORKFLOW_NAME: "Discover Student Benefits"
     outputs:
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}

--- a/.github/workflows/discover-benefits.md
+++ b/.github/workflows/discover-benefits.md
@@ -1,4 +1,5 @@
 ---
+name: Discover Student Benefits
 description: |
   Proactively discovers new student benefits not yet in the directory. First
   checks curated aggregator and program pages directly, then runs keyword

--- a/.github/workflows/discover-events.lock.yml
+++ b/.github/workflows/discover-events.lock.yml
@@ -22,13 +22,14 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 # Proactively discovers notable student events and hackathons not yet in the
-# feed. Searches the web for upcoming events, filters against existing entries,
-# removes expired entries, and opens PRs for the best new discoveries
-# (max 3 per run). Human approves all changes — nothing merges automatically.
+# feed. First checks a curated list of known high-value sources directly, then
+# runs keyword searches for unknown organizers. Removes expired entries and
+# opens PRs for the best new discoveries (max 3 per run). Human approves all
+# changes — nothing merges automatically.
 #
-# frontmatter-hash: 31b1fb303e28fe85ba115a47658a3ec3a6f3c8a6537df322069f62843039af33
+# frontmatter-hash: 91a1ae75c52d9e65a199a72344d23277998600e869fe7ea24f2cf762ae4882ba
 
-name: "Discover New Student Events"
+name: "Discover Student Events"
 "on":
   schedule:
   - cron: "7 6 * * 3"
@@ -40,7 +41,7 @@ permissions: {}
 concurrency:
   group: "gh-aw-${{ github.workflow }}"
 
-run-name: "Discover New Student Events"
+run-name: "Discover Student Events"
 
 jobs:
   activation:
@@ -144,7 +145,7 @@ jobs:
               version: "",
               agent_version: "0.0.410",
               cli_version: "v0.45.0",
-              workflow_name: "Discover New Student Events",
+              workflow_name: "Discover Student Events",
               experimental: false,
               supports_tools_allowlist: true,
               supports_http_transport: true,
@@ -824,7 +825,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: 1
-          GH_AW_WORKFLOW_NAME: "Discover New Student Events"
+          GH_AW_WORKFLOW_NAME: "Discover Student Events"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -837,7 +838,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Discover New Student Events"
+          GH_AW_WORKFLOW_NAME: "Discover Student Events"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -850,7 +851,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Discover New Student Events"
+          GH_AW_WORKFLOW_NAME: "Discover Student Events"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_WORKFLOW_ID: "discover-events"
@@ -868,7 +869,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Discover New Student Events"
+          GH_AW_WORKFLOW_NAME: "Discover Student Events"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
@@ -885,7 +886,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Discover New Student Events"
+          GH_AW_WORKFLOW_NAME: "Discover Student Events"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -930,8 +931,8 @@ jobs:
       - name: Setup threat detection
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "Discover New Student Events"
-          WORKFLOW_DESCRIPTION: "Proactively discovers notable student events and hackathons not yet in the\nfeed. Searches the web for upcoming events, filters against existing entries,\nremoves expired entries, and opens PRs for the best new discoveries\n(max 3 per run). Human approves all changes — nothing merges automatically."
+          WORKFLOW_NAME: "Discover Student Events"
+          WORKFLOW_DESCRIPTION: "Proactively discovers notable student events and hackathons not yet in the\nfeed. First checks a curated list of known high-value sources directly, then\nruns keyword searches for unknown organizers. Removes expired entries and\nopens PRs for the best new discoveries (max 3 per run). Human approves all\nchanges — nothing merges automatically."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1011,7 +1012,7 @@ jobs:
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: "claude-sonnet-4"
       GH_AW_WORKFLOW_ID: "discover-events"
-      GH_AW_WORKFLOW_NAME: "Discover New Student Events"
+      GH_AW_WORKFLOW_NAME: "Discover Student Events"
     outputs:
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}

--- a/.github/workflows/discover-events.md
+++ b/.github/workflows/discover-events.md
@@ -1,4 +1,5 @@
 ---
+name: Discover Student Events
 description: |
   Proactively discovers notable student events and hackathons not yet in the
   feed. First checks a curated list of known high-value sources directly, then

--- a/.github/workflows/maintain-benefits.lock.yml
+++ b/.github/workflows/maintain-benefits.lock.yml
@@ -22,12 +22,12 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 # Weekly maintenance pass over existing benefits.json entries. Checks link
-# health for every benefit, then applies the quality bar (specificity, self-serve,
-# direct student signup link, offer type accuracy) to flag entries that would
-# not pass today's review checklist. Opens or updates a single consolidated
-# issue with both categories of findings. Replaces check-links.yml.
+# health and quality bar for every benefit, then fixes each finding directly:
+# updates broken or redirected links, corrects offer_type mismatches, and
+# removes entries for programs that no longer exist. Opens a PR with all
+# changes. Human approves the merge — nothing lands automatically.
 #
-# frontmatter-hash: 0298c72303d2310e8e832e5fdaf885c23cf5840c692335c0b806ec3dd767f29f
+# frontmatter-hash: a86152c9bdb3b1cc3f72d5e260b3c869ec47387dfd1c819f2ceb67ca15b72342
 
 name: "Maintain Benefits"
 "on":
@@ -99,6 +99,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - name: Configure Git credentials
@@ -198,40 +203,56 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"create_issue":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"close_issue":{"max":1},"create_pull_request":{},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
             {
-              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 1 issue(s) can be created. Labels [link-health needs-review] will be automatically added.",
+              "description": "Close a GitHub issue with a closing comment. You can and should always add a comment when closing an issue to explain the action or provide context. This tool is ONLY for closing issues - use update_issue if you need to change the title, body, labels, or other metadata without closing. Use close_issue when work is complete, the issue is no longer relevant, or it's a duplicate. The closing comment should explain the resolution or reason for closing. If the issue is already closed, a comment will still be posted. CONSTRAINTS: Maximum 1 issue(s) can be closed.",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
                   "body": {
-                    "description": "Detailed issue description in Markdown. Do NOT repeat the title as a heading since it already appears as the issue's h1. Include context, reproduction steps, or acceptance criteria as appropriate.",
+                    "description": "Closing comment explaining why the issue is being closed and summarizing any resolution, workaround, or conclusion.",
+                    "type": "string"
+                  },
+                  "issue_number": {
+                    "description": "Issue number to close. This is the numeric ID from the GitHub URL (e.g., 901 in github.com/owner/repo/issues/901). If omitted, closes the issue that triggered this workflow (requires an issue event trigger).",
+                    "type": [
+                      "number",
+                      "string"
+                    ]
+                  }
+                },
+                "required": [
+                  "body"
+                ],
+                "type": "object"
+              },
+              "name": "close_issue"
+            },
+            {
+              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 1 pull request(s) can be created.",
+              "inputSchema": {
+                "additionalProperties": false,
+                "properties": {
+                  "body": {
+                    "description": "Detailed PR description in Markdown. Include what changes were made, why, testing notes, and any breaking changes. Do NOT repeat the title as a heading.",
+                    "type": "string"
+                  },
+                  "branch": {
+                    "description": "Source branch name containing the changes. If omitted, uses the current working branch.",
                     "type": "string"
                   },
                   "labels": {
-                    "description": "Labels to categorize the issue (e.g., 'bug', 'enhancement'). Labels must exist in the repository.",
+                    "description": "Labels to categorize the PR (e.g., 'enhancement', 'bugfix'). Labels must exist in the repository.",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
-                  "parent": {
-                    "description": "Parent issue number for creating sub-issues. This is the numeric ID from the GitHub URL (e.g., 42 in github.com/owner/repo/issues/42). Can also be a temporary_id (e.g., 'aw_abc123', 'aw_Test123') from a previously created issue in the same workflow run.",
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "temporary_id": {
-                    "description": "Unique temporary identifier for referencing this issue before it's created. Format: 'aw_' followed by 3 to 8 alphanumeric characters (e.g., 'aw_abc1', 'aw_Test123'). Use '#aw_ID' in body text to reference other issues by their temporary_id; these are replaced with actual issue numbers after creation.",
-                    "pattern": "^aw_[A-Za-z0-9]{4,8}$",
-                    "type": "string"
-                  },
                   "title": {
-                    "description": "Concise issue title summarizing the bug, feature, or task. The title appears as the main heading, so keep it brief and descriptive.",
+                    "description": "Concise PR title describing the changes. Follow repository conventions (e.g., conventional commits). The title appears as the main heading.",
                     "type": "string"
                   }
                 },
@@ -241,7 +262,7 @@ jobs:
                 ],
                 "type": "object"
               },
-              "name": "create_issue"
+              "name": "create_pull_request"
             },
             {
               "description": "Report that a tool or capability needed to complete the task is not available, or share any information you deem important about missing functionality or limitations. Use this when you cannot accomplish what was requested because the required functionality is missing or access is restricted.",
@@ -316,7 +337,7 @@ jobs:
           GH_AW_SAFE_OUTPUTS_TOOLS_EOF
           cat > /opt/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_EOF'
           {
-            "create_issue": {
+            "close_issue": {
               "defaultMax": 1,
               "fields": {
                 "body": {
@@ -325,21 +346,31 @@ jobs:
                   "sanitize": true,
                   "maxLength": 65000
                 },
+                "issue_number": {
+                  "optionalPositiveInteger": true
+                }
+              }
+            },
+            "create_pull_request": {
+              "defaultMax": 1,
+              "fields": {
+                "body": {
+                  "required": true,
+                  "type": "string",
+                  "sanitize": true,
+                  "maxLength": 65000
+                },
+                "branch": {
+                  "required": true,
+                  "type": "string",
+                  "sanitize": true,
+                  "maxLength": 256
+                },
                 "labels": {
                   "type": "array",
                   "itemType": "string",
                   "itemSanitize": true,
                   "itemMaxLength": 128
-                },
-                "parent": {
-                  "issueOrPRNumber": true
-                },
-                "repo": {
-                  "type": "string",
-                  "maxLength": 256
-                },
-                "temporary_id": {
-                  "type": "string"
                 },
                 "title": {
                   "required": true,
@@ -429,6 +460,7 @@ jobs:
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
           GITHUB_MCP_LOCKDOWN: ${{ steps.determine-automatic-lockdown.outputs.lockdown == 'true' && '1' || '0' }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
         run: |
           set -eo pipefail
           mkdir -p /tmp/gh-aw/mcp-config
@@ -444,7 +476,7 @@ jobs:
           export DEBUG="*"
           
           export GH_AW_ENGINE="copilot"
-          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_LOCKDOWN -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.1.4'
+          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_LOCKDOWN -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e TAVILY_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.1.4'
           
           mkdir -p /home/runner/.copilot
           cat << GH_AW_MCP_CONFIG_EOF | bash /opt/gh-aw/actions/start_mcp_gateway.sh
@@ -457,7 +489,7 @@ jobs:
                   "GITHUB_LOCKDOWN_MODE": "$GITHUB_MCP_LOCKDOWN",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_MCP_SERVER_TOKEN}",
                   "GITHUB_READ_ONLY": "1",
-                  "GITHUB_TOOLSETS": "issues,repos"
+                  "GITHUB_TOOLSETS": "issues,pull_requests,repos"
                 }
               },
               "safeoutputs": {
@@ -465,6 +497,22 @@ jobs:
                 "url": "http://host.docker.internal:$GH_AW_SAFE_OUTPUTS_PORT",
                 "headers": {
                   "Authorization": "\${GH_AW_SAFE_OUTPUTS_API_KEY}"
+                }
+              },
+              "tavily": {
+                "type": "stdio",
+                "container": "node:lts-alpine",
+                "entrypoint": "npx",
+                "entrypointArgs": [
+                  "npx",
+                  "-y",
+                  "@tavily/mcp-server"
+                ],
+                "tools": [
+                  "search"
+                ],
+                "env": {
+                  "TAVILY_API_KEY": "\${TAVILY_API_KEY}"
                 }
               }
             },
@@ -619,7 +667,7 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 30
+        timeout-minutes: 45
         run: |
           set -o pipefail
           sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --allow-domains '*.com,*.dev,*.edu,*.io,*.net,*.org,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --enable-host-access --image-tag 0.18.0 --skip-pull \
@@ -682,11 +730,12 @@ jobs:
             const { main } = require('/opt/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN,TAVILY_API_KEY'
           SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SECRET_TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
       - name: Upload Safe Outputs
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -772,6 +821,7 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/logs/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
+            /tmp/gh-aw/aw.patch
           if-no-files-found: ignore
 
   conclusion:
@@ -783,8 +833,9 @@ jobs:
     if: (always()) && (needs.agent.result != 'skipped')
     runs-on: ubuntu-slim
     permissions:
-      contents: read
+      contents: write
       issues: write
+      pull-requests: write
     outputs:
       noop_message: ${{ steps.noop.outputs.noop_message }}
       tools_reported: ${{ steps.missing_tool.outputs.tools_reported }}
@@ -867,6 +918,20 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/handle_noop_message.cjs');
             await main();
+      - name: Handle Create Pull Request Error
+        id: handle_create_pr_error
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
+          GH_AW_WORKFLOW_NAME: "Maintain Benefits"
+          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('/opt/gh-aw/actions/handle_create_pr_error.cjs');
+            await main();
 
   detection:
     needs: agent
@@ -904,7 +969,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           WORKFLOW_NAME: "Maintain Benefits"
-          WORKFLOW_DESCRIPTION: "Weekly maintenance pass over existing benefits.json entries. Checks link\nhealth for every benefit, then applies the quality bar (specificity, self-serve,\ndirect student signup link, offer type accuracy) to flag entries that would\nnot pass today's review checklist. Opens or updates a single consolidated\nissue with both categories of findings. Replaces check-links.yml."
+          WORKFLOW_DESCRIPTION: "Weekly maintenance pass over existing benefits.json entries. Checks link\nhealth and quality bar for every benefit, then fixes each finding directly:\nupdates broken or redirected links, corrects offer_type mismatches, and\nremoves entries for programs that no longer exist. Opens a PR with all\nchanges. Human approves the merge — nothing lands automatically."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -970,13 +1035,15 @@ jobs:
 
   safe_outputs:
     needs:
+      - activation
       - agent
       - detection
     if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (needs.detection.outputs.success == 'true')
     runs-on: ubuntu-slim
     permissions:
-      contents: read
+      contents: write
       issues: write
+      pull-requests: write
     timeout-minutes: 15
     env:
       GH_AW_ENGINE_ID: "copilot"
@@ -1004,12 +1071,38 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs/
           find "/tmp/gh-aw/safeoutputs/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/safeoutputs/agent_output.json" >> "$GITHUB_ENV"
+      - name: Download patch artifact
+        continue-on-error: true
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: agent-artifacts
+          path: /tmp/gh-aw/
+      - name: Checkout repository
+        if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ github.token }}
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Configure Git credentials
+        if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+        env:
+          REPO_NAME: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+          GIT_TOKEN: ${{ github.token }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          # Re-authenticate git with GitHub token
+          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
+          git remote set-url origin "https://x-access-token:${GIT_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          echo "Git configured with standard GitHub Actions identity"
       - name: Process Safe Outputs
         id: process_safe_outputs
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"link-health\",\"needs-review\"],\"max\":1},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"close_issue\":{\"max\":1},\"create_pull_request\":{\"base_branch\":\"main\",\"max\":1,\"max_patch_size\":1024},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/maintain-benefits.md
+++ b/.github/workflows/maintain-benefits.md
@@ -1,10 +1,11 @@
 ---
+name: Maintain Benefits
 description: |
   Weekly maintenance pass over existing benefits.json entries. Checks link
-  health for every benefit, then applies the quality bar (specificity, self-serve,
-  direct student signup link, offer type accuracy) to flag entries that would
-  not pass today's review checklist. Opens or updates a single consolidated
-  issue with both categories of findings. Replaces check-links.yml.
+  health and quality bar for every benefit, then fixes each finding directly:
+  updates broken or redirected links, corrects offer_type mismatches, and
+  removes entries for programs that no longer exist. Opens a PR with all
+  changes. Human approves the merge — nothing lands automatically.
 
 strict: false
 
@@ -20,13 +21,23 @@ on:
 permissions: read-all
 
 safe-outputs:
-  create-issue:
-    labels: [link-health, needs-review]
+  create-pull-request:
+    base-branch: main
+  close-issue:
+
+mcp-servers:
+  tavily:
+    command: npx
+    args: ["-y", "@tavily/mcp-server"]
+    env:
+      TAVILY_API_KEY: "${{ secrets.TAVILY_API_KEY }}"
+    allowed: ["search"]
 
 tools:
   github:
-    toolsets: [issues, repos]
+    toolsets: [issues, pull_requests, repos]
   web-fetch:
+  edit:
 
 network:
   allowed:
@@ -39,16 +50,16 @@ network:
     - "*.dev"
     - "*.net"
 
-timeout-minutes: 30
+timeout-minutes: 45
 ---
 
 # Maintain Benefits
 
-You audit all existing `benefits.json` entries for link health and quality, then open or update a single consolidated GitHub issue with the findings.
+You audit all existing `benefits.json` entries for link health and quality, fix every finding you can, and open a PR with the changes. You do not open issues — findings go directly to a PR.
 
 ## Step 1: Read existing data
 
-Read `benefits.json` and `categories.json` from the repository.
+Read `benefits.json` from the repository.
 
 Note today's UTC date (ISO 8601).
 
@@ -57,59 +68,80 @@ Note today's UTC date (ISO 8601).
 For each benefit in `benefits.json`, fetch its `link` with `web-fetch`. Classify each result:
 
 - **Broken**: fetch fails (network error, DNS failure, or the returned page clearly indicates a 404 / "not found"). Skip 403 responses — that is commonly bot-blocking, not a broken page.
-- **Redirected**: the final URL's hostname differs from the original URL's hostname (cross-domain redirect, likely a moved or acquired product). Same-domain path changes are not redirects.
+- **Redirected**: the final URL's hostname differs from the original URL's hostname (cross-domain redirect). Same-domain path changes are not redirects.
 - **Healthy**: anything else.
 
-Collect broken and redirected benefits. Rate-limit to one request per second to avoid triggering bot-blocking.
+Collect broken and redirected benefits. Rate-limit to one request per second.
 
 ## Step 3: Quality review
 
-For each benefit in `benefits.json`, apply the quality bar. Treat link health from Step 2 as one input — a broken link is automatic failure regardless of other criteria.
+For each benefit in `benefits.json`, apply the quality bar. Only flag when the violation is unambiguous. If you are uncertain, skip it.
 
-Only flag a benefit when the violation is unambiguous. If you are uncertain, skip it.
+1. **Specific offer**: description must contain at least one concrete signal — a percentage, a dollar or credit amount, a plan name, or a duration. Flag if none are present and the description reads as a generic statement.
+2. **Direct signup link**: flag only if the URL path is exactly `/` or `/home`, or the subdomain is clearly non-enrollment (`support.`, `docs.`, `help.`, `blog.`) AND the path does not contain an enrollment keyword (`/edu`, `/education`, `/student`, `/students`, `/enrollment`). URL structure only — do not flag based on page content.
+3. **Self-serve**: flag only if the `description` itself contains language like "through your university", "ask your institution", or "contact IT".
+4. **Offer type accuracy**: flag only clear mismatches — description says "% off" or "discount" but `offer_type` is `free`; or description says "free" but `offer_type` is `discount`.
+5. **Description length**: flag if `description` exceeds 120 characters (mechanical count).
 
-1. **Specific offer**: description must contain at least one concrete signal — a percentage, a dollar or credit amount, a plan name, or a duration. Flag if the description contains none of these and reads as a generic statement (e.g. "Student discount available", "Free access through your university"). Do not flag if the description is short but still names a concrete plan.
-2. **Direct signup link**: flag only if the URL path is exactly `/` or `/home` (root homepage), or the subdomain is clearly non-enrollment (e.g. `support.`, `docs.`, `help.`, `blog.`). Do not flag based on page content — URL structure only.
-3. **Self-serve**: flag only if the `description` itself contains language like "through your university", "ask your institution", or "contact IT". Do not fetch the page to make this determination.
-4. **Offer type accuracy**: `offer_type` must match what the description says. Flag only clear mismatches: description says "% off" or "discount" but `offer_type` is `free`; description says "free" but `offer_type` is `discount`.
-5. **Description length**: `description` is ≤ 120 characters. Flag if over — this is mechanical, count the characters.
+## Step 4: Fix each finding
 
-For each flagged benefit, record which criterion failed and a brief reason.
+Work through every finding from Steps 2 and 3. For each one, attempt a fix.
 
-## Step 4: Open or update the maintenance issue
+### Broken or redirected links
 
-Check for an existing open GitHub issue labeled `link-health`.
+Use the Tavily `search` tool with a query like `"{benefit name}" student discount signup`. Then use `web-fetch` to verify the top result.
 
-Build the issue body using this format:
+- If a valid student signup page is found: update `link` to the correct URL.
+- If the program no longer exists (no student page found after search): remove the entire entry from `benefits.json`.
 
+For redirected links: if the redirect destination is a valid student signup page, update `link` to the destination URL. If not, treat as broken.
+
+### Quality flags
+
+- **Direct signup link** (root URL): use Tavily to find the direct student signup page. Update `link` if found; otherwise leave unchanged.
+- **Offer type mismatch**: update `offer_type` to match what the description says.
+- **Description length**: trim the `description` to ≤ 120 characters without losing the essential offer details. If trimming would lose meaning, leave unchanged.
+- **Specific offer** or **Self-serve**: only fix if the correct information is clearly findable via web-fetch. If uncertain, leave unchanged.
+
+## Step 5: Apply changes to benefits.json
+
+If any fixes were made (updates or removals), edit `benefits.json`:
+- Preserve 2-space indent and trailing newline
+- Maintain the existing entry order; do not reorder
+
+## Step 6: Open a PR (only if fixes were made)
+
+If no fixes were made, skip to Step 7.
+
+Open a single pull request with all changes.
+
+**Branch**: `maintain-benefits-{today's date as YYYY-MM-DD}`
+
+**Title**: `[Maintenance]: Fix {N} benefit(s)` where N is the number of entries changed or removed.
+
+**Body**:
 ```
-## Weekly Benefit Maintenance Report
+## Summary
 
-_Last checked: <today's date>_
+<one sentence describing what changed overall>
 
-### Link Health
+### Fixed
+| Benefit | Issue | Change |
+|---------|-------|--------|
+| {name} | {broken link / redirected / offer_type mismatch / ...} | {what was changed} |
 
-<If no findings: "All links healthy.">
-
-**Broken**
-| Benefit | Link | Reason |
-|---------|------|--------|
-
-**Redirected (cross-domain)**
-| Benefit | Original | Now Points To |
-|---------|----------|--------------|
-
-### Quality Flags
-
-<If no findings: "All entries pass the quality bar.">
-
-| Benefit | Criterion | Reason |
-|---------|-----------|--------|
+### Removed
+| Benefit | Reason |
+|---------|--------|
+| {name} | Program no longer offers a student benefit |
 ```
 
-If an open `link-health` issue exists, update its body with the new report. Otherwise, create a new issue:
+Omit the Removed section if no entries were removed. Omit the Fixed section if no entries were updated.
 
-- **Title**: `Benefit Maintenance: <N> issue(s) found` (N = total broken + redirected + quality flags)
-- **Labels**: `link-health`, `needs-review`
+## Step 7: Close any open link-health issues
 
-If there are no findings at all, do not open or update any issue — stop here.
+Check for any open GitHub issues labeled `link-health`. Close each one with a comment that matches the outcome:
+
+- **No findings from Steps 2 or 3**: "All benefits are healthy."
+- **Findings existed but none were fixable** (every fix attempt was uncertain or unsuccessful): "Found {N} issue(s) that require manual review: {list benefit names}."
+- **PR was opened**: "Fixed in PR #{pr_number}."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ AI-driven workflows live in `.github/workflows/`:
 | `add-benefit.md` | Issue labeled `new-benefit` | Validates submission, deduplicates, creates PR |
 | `discover-benefits.md` | Weekly (Monday) or manual | Searches the web for new benefits, opens issues for the best discoveries |
 | `discover-events.md` | Weekly (Wednesday) or manual | Searches for notable student events, removes expired entries, opens PRs |
-| `maintain-benefits.md` | Weekly (Sunday) or manual | Checks all benefit links and re-audits existing entries against the quality bar; opens or updates a consolidated issue |
+| `maintain-benefits.md` | Weekly (Sunday) or manual | Checks all benefit links and re-audits existing entries against the quality bar; fixes findings directly and opens a PR |
 
 The compiled `.lock.yml` files are auto-generated — **never edit them directly**.
 To change a workflow, edit the `.md` source and run `gh aw compile`.
@@ -104,16 +104,13 @@ Flag the issue and stop — do not approve PRs that fail any of these.
 
 ---
 
-## Maintenance issue workflow
+## Handling link-health issues mid-week
 
-When a maintenance issue appears (labeled `link-health`):
+The `maintain-benefits` workflow runs every Sunday and closes open `link-health` issues automatically. If one appears mid-week (filed via the report-broken template or a prior run), either wait for Sunday or trigger the workflow manually:
 
-1. Read the issue body — it contains both broken/redirected links and quality flags
-2. For each broken or redirected benefit, find the current correct student program URL
-   (use WebFetch to verify it resolves to a real page)
-3. For each quality flag, fix the description, link, or offer_type as needed — or remove the entry if it no longer meets the quality bar
-4. Update `benefits.json` with all corrections
-5. Open a PR that closes the maintenance issue
+```
+gh workflow run maintain-benefits.lock.yml --repo student-benefits/student-benefits.github.io
+```
 
 ---
 

--- a/agent/index.html
+++ b/agent/index.html
@@ -43,7 +43,7 @@
           </button>
           <button class="arch-node arch-node--github" id="node-schedule" aria-expanded="false" aria-controls="panel-schedule">
             <span class="arch-node-label">Schedule</span>
-            <span class="arch-node-sublabel">Mon + Wed weekly</span>
+            <span class="arch-node-sublabel">Mon, Wed + Sun weekly</span>
           </button>
         </div>
 
@@ -110,7 +110,7 @@
         </div>
         <div id="panel-schedule" class="node-panel" hidden>
           <p class="node-panel-title">Weekly Schedule</p>
-          <p>Three scheduled workflows run without human prompting. On Mondays, <code>discover-benefits</code> searches the web for new student programs and opens GitHub issues for the best discoveries — feeding Grant's own queue. On Wednesdays, <code>discover-events</code> searches for notable student events, removes expired entries, and opens PRs directly. On Sundays, <code>maintain-benefits</code> checks every existing entry for broken links and quality issues, and opens a consolidated issue with any findings.</p>
+          <p>Three scheduled workflows run without human prompting. On Mondays, <code>discover-benefits</code> searches the web for new student programs and opens GitHub issues for the best discoveries — feeding Grant's own queue. On Wednesdays, <code>discover-events</code> searches for notable student events, removes expired entries, and opens PRs directly. On Sundays, <code>maintain-benefits</code> checks every existing entry for broken links and quality issues, fixes what it can, and opens a PR with the changes.</p>
         </div>
         <div id="panel-grant" class="node-panel" hidden>
           <p class="node-panel-title">Grant · Claude Sonnet 4</p>
@@ -126,7 +126,7 @@
         </div>
         <div id="panel-output" class="node-panel" hidden>
           <p class="node-panel-title">GitHub Output</p>
-          <p>Grant's outputs depend on the workflow. For submissions: if valid and new, it opens a pull request and comments on the issue; if rejected or duplicate, it comments with the reason and closes the issue. For <code>discover-benefits</code>: it opens new issues for the best discoveries it found. For <code>discover-events</code>: it opens a PR directly. For <code>maintain-benefits</code>: it opens or updates a consolidated issue listing broken links and quality flags. All writes go through GitHub's API. PRs wait for a human reviewer to merge — Grant cannot publish directly.</p>
+          <p>Grant's outputs depend on the workflow. For submissions: if valid and new, it opens a pull request and comments on the issue; if rejected or duplicate, it comments with the reason and closes the issue. For <code>discover-benefits</code>: it opens new issues for the best discoveries it found. For <code>discover-events</code>: it opens a PR directly. For <code>maintain-benefits</code>: it fixes broken links and quality flags directly in <code>benefits.json</code> and opens a PR. All writes go through GitHub's API. PRs wait for a human reviewer to merge — Grant cannot publish directly.</p>
         </div>
         <div id="panel-human" class="node-panel" hidden>
           <p class="node-panel-title">Human Reviewer</p>
@@ -246,7 +246,7 @@
 </main>
 
 <footer class="site-footer">
-  <p>Grant is open source. <a href="https://github.com/student-benefits/student-benefits.github.io/blob/main/.github/workflows/add-benefit.md" target="_blank" rel="noopener noreferrer">Read the workflow</a> to see exactly what it does, or open an issue to suggest a new benefit and watch it run for real.</p>
+  <p>Grant is open source. <a href="https://github.com/student-benefits/student-benefits.github.io/tree/main/.github/workflows" target="_blank" rel="noopener noreferrer">Read the workflows</a> to see exactly what it does, or open an issue to suggest a new benefit and watch it run for real.</p>
 </footer>
 
 <script src="/shared.js"></script>

--- a/benefits.json
+++ b/benefits.json
@@ -72,7 +72,7 @@
     "repo": "JetBrains/intellij-community"
   },
   {
-    "id": "perplexity",
+    "id": "perplexity-pro",
     "name": "Perplexity Pro",
     "category": "AI Tools",
     "offer_type": "discount",
@@ -88,7 +88,7 @@
   {
     "id": "1password",
     "name": "1Password",
-    "category": "Domains & Security",
+    "category": "Security",
     "offer_type": "free",
     "description": "Free for 1 year via GitHub Student Pack. Password manager with SSH agent and CLI integration.",
     "link": "https://1password.com/developers/students",
@@ -100,7 +100,7 @@
     "popularity": 8
   },
   {
-    "id": "azure-credits",
+    "id": "microsoft-azure",
     "name": "Microsoft Azure",
     "category": "Cloud & Hosting",
     "offer_type": "credits",
@@ -186,8 +186,8 @@
   },
   {
     "id": "namecheap",
-    "name": "Namecheap Free Domain",
-    "category": "Domains & Security",
+    "name": "Namecheap",
+    "category": "Dev Tools",
     "offer_type": "free",
     "description": "Free .me domain for 1 year plus SSL certificate. Available to students with .edu email addresses worldwide.",
     "link": "https://nc.me/",
@@ -450,7 +450,7 @@
   },
   {
     "id": "cloudflare-workers",
-    "name": "Cloudflare Workers (Student)",
+    "name": "Cloudflare Workers",
     "category": "Cloud & Hosting",
     "offer_type": "free",
     "description": "Free Workers Paid Plan for 1 year. Includes Workers, Pages Functions, KV, and Durable Objects.",
@@ -491,7 +491,7 @@
     "popularity": 8
   },
   {
-    "id": "sketch-education",
+    "id": "sketch",
     "name": "Sketch",
     "category": "Design",
     "offer_type": "free",
@@ -728,7 +728,7 @@
     "popularity": 6
   },
   {
-    "id": "gdsc",
+    "id": "google-student-clubs",
     "name": "Google Developer Student Clubs",
     "category": "Learning",
     "offer_type": "free",

--- a/categories.json
+++ b/categories.json
@@ -1,1 +1,1 @@
-["AI Tools", "Dev Tools", "Cloud & Hosting", "Learning", "Design", "Productivity", "Lifestyle", "Domains & Security"]
+["AI Tools", "Dev Tools", "Cloud & Hosting", "Learning", "Design", "Productivity", "Lifestyle", "Security"]


### PR DESCRIPTION
## Summary

- Renames all four workflows to a consistent verb-noun form and fixes PR title prefix casing
- Unifies the `link-health` label so human-filed reports route through the same path as automated findings
- Renames \"Domains & Security\" → \"Security\"; moves Namecheap to Dev Tools, 1Password to Security
- Fixes inconsistent benefit IDs (`perplexity-pro`, `microsoft-azure`, `sketch`, `google-student-clubs`) and removes offer type / project-added qualifiers from benefit names
- Rewrites `maintain-benefits` to fix findings directly and open a PR instead of reporting via issue; adds Tavily for finding replacement URLs, handles three terminal states (clean / unfixable / fixed), consolidates close-issue logic, and exempts enrollment-path URLs from subdomain flagging
- Adds mid-week `link-health` guidance to CLAUDE.md
- Updates `agent/index.html` schedule and output panels; fixes footer to link to the workflows directory