### PR TITLE
Fix update-gh-aw: use GH_PAT for workflow file push

### DIFF
--- a/.github/workflows/update-gh-aw.yml
+++ b/.github/workflows/update-gh-aw.yml
@@ -44,7 +44,10 @@ jobs:
       - name: Open PR
         if: steps.versions.outputs.current != steps.versions.outputs.latest
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Pushing workflow files requires a PAT with the `workflow` scope.
+          # Create one at Settings > Developer settings > Personal access tokens
+          # and store it as the GH_PAT repository secret.
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           CURRENT: ${{ steps.versions.outputs.current }}
           LATEST: ${{ steps.versions.outputs.latest }}
         run: |
@@ -63,6 +66,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}"
           git checkout -b "$BRANCH"
           git add .github/workflows/*.lock.yml .github/aw/
           git commit -m "Upgrade gh-aw from $CURRENT to $LATEST"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ AI-driven workflows live in `.github/workflows/`:
 The compiled `.lock.yml` files are auto-generated — **never edit them directly**.
 To change a workflow, edit the `.md` source and run `gh aw compile`.
 
-`update-gh-aw.yml` runs every Tuesday, checks for a newer gh-aw release, recompiles all lock files, and opens a PR. It is a plain `.yml` — do not compile it with `gh aw`.
+`update-gh-aw.yml` runs every Tuesday, checks for a newer gh-aw release, recompiles all lock files, and opens a PR. It is a plain `.yml` — do not compile it with `gh aw`. Requires a `GH_PAT` repository secret (a PAT with `workflow` scope) to push workflow file changes.
 
 ---
 


### PR DESCRIPTION
github.token cannot push changes to .github/workflows/ files. Switches the push step to use a GH_PAT secret (PAT with workflow scope). Requires adding GH_PAT as a repository secret before the workflow can fully run.