### PR TITLE
Simplify update-gh-aw: open issue instead of PR

### DIFF
--- a/.github/workflows/update-gh-aw.yml
+++ b/.github/workflows/update-gh-aw.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  issues: write
 
 jobs:
   update:
@@ -26,65 +26,42 @@ jobs:
           echo "latest=$LATEST" >> $GITHUB_OUTPUT
           echo "Current: $CURRENT, Latest: $LATEST"
 
-      - name: Install gh-aw ${{ steps.versions.outputs.latest }}
+      - name: Open issue if behind
         if: steps.versions.outputs.current != steps.versions.outputs.latest
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh extension install github/gh-aw
-
-      - name: Recompile all workflows
-        if: steps.versions.outputs.current != steps.versions.outputs.latest
-        run: |
-          gh aw compile \
-            .github/workflows/add-benefit.md \
-            .github/workflows/discover-benefits.md \
-            .github/workflows/discover-events.md \
-            .github/workflows/maintain-benefits.md
-
-      - name: Open PR
-        if: steps.versions.outputs.current != steps.versions.outputs.latest
-        env:
-          # Pushing workflow files requires a PAT with the `workflow` scope.
-          # Create one at Settings > Developer settings > Personal access tokens
-          # and store it as the GH_PAT repository secret.
-          GH_TOKEN: ${{ secrets.GH_PAT }}
           CURRENT: ${{ steps.versions.outputs.current }}
           LATEST: ${{ steps.versions.outputs.latest }}
         run: |
-          if [ -z "$(git diff --name-only)" ]; then
-            echo "No file changes after recompile -- skipping PR."
+          # Don't open a duplicate issue if one already exists for this version
+          EXISTING=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "agentic-workflows" \
+            --search "gh-aw $LATEST in:title" \
+            --json number \
+            --jq 'length')
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Issue for $LATEST already exists -- skipping."
             exit 0
           fi
 
-          BRANCH="update-gh-aw-${LATEST}"
-
-          # Don't open a duplicate PR if one already exists
-          if gh pr view "$BRANCH" --json state -q '.state' 2>/dev/null | grep -q OPEN; then
-            echo "PR for $BRANCH already open -- skipping."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}"
-          git checkout -b "$BRANCH"
-          git add .github/workflows/*.lock.yml .github/aw/
-          git commit -m "Upgrade gh-aw from $CURRENT to $LATEST"
-          git push origin "$BRANCH"
-
-          gh pr create \
+          gh issue create \
             --title "Upgrade gh-aw $CURRENT to $LATEST" \
-            --base main \
-            --head "$BRANCH" \
-            --body "$(cat <<EOF
-          Automated recompile of all workflow lock files with gh-aw $LATEST.
+            --label "agentic-workflows" \
+            --body "gh-aw $LATEST is available (currently on $CURRENT).
 
-          ## Changes
-          - Recompiled \`add-benefit.lock.yml\`
-          - Recompiled \`discover-benefits.lock.yml\`
-          - Recompiled \`discover-events.lock.yml\`
-          - Recompiled \`maintain-benefits.lock.yml\`
+          To upgrade, run locally:
 
-          Review the diff to confirm no unexpected behavioural changes before merging.
-          EOF
-          )"
+          \`\`\`sh
+          gh extension upgrade aw
+          gh aw compile \\
+            .github/workflows/add-benefit.md \\
+            .github/workflows/discover-benefits.md \\
+            .github/workflows/discover-events.md \\
+            .github/workflows/maintain-benefits.md
+          \`\`\`
+
+          Then commit and push the updated lock files.
+
+          See the [gh-aw release notes](https://github.com/github/gh-aw/releases/tag/$LATEST) for what changed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ AI-driven workflows live in `.github/workflows/`:
 The compiled `.lock.yml` files are auto-generated — **never edit them directly**.
 To change a workflow, edit the `.md` source and run `gh aw compile`.
 
-`update-gh-aw.yml` runs every Tuesday, checks for a newer gh-aw release, recompiles all lock files, and opens a PR. It is a plain `.yml` — do not compile it with `gh aw`. Requires a `GH_PAT` repository secret (a PAT with `workflow` scope) to push workflow file changes.
+`update-gh-aw.yml` runs every Tuesday, checks for a newer gh-aw release, and opens an issue with upgrade instructions if behind. It is a plain `.yml` — do not compile it with `gh aw`.
 
 ---
 


### PR DESCRIPTION
Drops the PAT requirement entirely. When a new gh-aw version is detected, opens an issue with the two commands needed to upgrade locally. No secrets needed.