### PR TITLE
Fix git push auth in update-gh-aw

### DIFF
--- a/.github/workflows/update-gh-aw.yml
+++ b/.github/workflows/update-gh-aw.yml
@@ -61,6 +61,8 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Remove the checkout-injected credential header so the PAT in the remote URL is used
+          git config --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}"
           git checkout -b "$BRANCH"
           git add .github/workflows/*.lock.yml .github/aw/


### PR DESCRIPTION
## Summary

`actions/checkout` injects an `http.https://github.com/.extraheader` git config that overrides the PAT set via `git remote set-url`, causing the push to use `github-actions[bot]` credentials and fail with 403.

Unsets the header before pushing so the PAT remote URL takes effect.

## Test plan
- [ ] Trigger `Update gh-aw` workflow manually — should push branch and open PR successfully