### PR TITLE
Force push upgrade branch in update-gh-aw

### DIFF
--- a/.github/workflows/update-gh-aw.yml
+++ b/.github/workflows/update-gh-aw.yml
@@ -67,7 +67,7 @@ jobs:
           git checkout -b "$BRANCH"
           git add .github/workflows/*.lock.yml .github/aw/
           git commit -m "Upgrade gh-aw from $CURRENT to $LATEST"
-          git push origin "$BRANCH"
+          git push --force origin "$BRANCH"
 
           gh pr create \
             --title "Upgrade gh-aw $CURRENT to $LATEST" \


### PR DESCRIPTION
## Summary

Use `git push --force` when pushing the upgrade branch so reruns don't fail if the branch already exists from a previous attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)