### PR TITLE
Remove Submit an event button from main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,10 +30,6 @@
               <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
               Submit a benefit
             </a>
-            <a href="https://github.com/student-benefits/student-benefits.github.io/issues/new?template=new-event.yml" target="_blank" rel="noopener noreferrer" class="contribute-banner">
-              <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
-              Submit an event
-            </a>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Removes the "Submit an event" button from the main page header. The button belongs on the events page where users are already browsing events — not on the benefits directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)