### PR TITLE
Fix Tavily allowed tool names in all workflows

### DIFF
--- a/.github/workflows/add-benefit.lock.yml
+++ b/.github/workflows/add-benefit.lock.yml
@@ -25,7 +25,7 @@
 # validates the benefit, checks for duplicates against benefits.json,
 # and creates a PR with the new entry if valid.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"27b7cf588dc9c7c2dab0277c72aa69cb1b7853b21b52dfbaabf9d24b01125326","compiler_version":"v0.56.2"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"d5aebbba9c8a812586796e434774220310ce965e73ce4f219703889334228262","compiler_version":"v0.56.2"}
 
 name: "Add Benefit"
 "on":
@@ -795,8 +795,7 @@ jobs:
                   "tavily-mcp"
                 ],
                 "tools": [
-                  "search",
-                  "search_news"
+                  "tavily_search"
                 ],
                 "env": {
                   "TAVILY_API_KEY": "\${TAVILY_API_KEY}"

--- a/.github/workflows/add-benefit.md
+++ b/.github/workflows/add-benefit.md
@@ -33,7 +33,7 @@ mcp-servers:
     args: ["-y", "tavily-mcp"]
     env:
       TAVILY_API_KEY: "${{ secrets.TAVILY_API_KEY }}"
-    allowed: ["search", "search_news"]
+    allowed: ["tavily_search"]
 
 tools:
   github:

--- a/.github/workflows/add-event.lock.yml
+++ b/.github/workflows/add-event.lock.yml
@@ -25,7 +25,7 @@
 # validates the event against the quality bar, checks for duplicates against
 # events.json, and creates a PR with the new entry if valid.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4a3852c7d4eb025bca2b8360d1bbc67be3c707518dbbd95f9c2cff687c165c4a","compiler_version":"v0.56.2"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"9f6c7265ac54d5b0dfe9792ff57ab6a05bea1cc02a9f2e54a3f7add23d6abecd","compiler_version":"v0.56.2"}
 
 name: "Add Event"
 "on":
@@ -795,8 +795,7 @@ jobs:
                   "tavily-mcp"
                 ],
                 "tools": [
-                  "search",
-                  "search_news"
+                  "tavily_search"
                 ],
                 "env": {
                   "TAVILY_API_KEY": "\${TAVILY_API_KEY}"

--- a/.github/workflows/add-event.md
+++ b/.github/workflows/add-event.md
@@ -33,7 +33,7 @@ mcp-servers:
     args: ["-y", "tavily-mcp"]
     env:
       TAVILY_API_KEY: "${{ secrets.TAVILY_API_KEY }}"
-    allowed: ["search", "search_news"]
+    allowed: ["tavily_search"]
 
 tools:
   github:

--- a/.github/workflows/discover-benefits.lock.yml
+++ b/.github/workflows/discover-benefits.lock.yml
@@ -27,7 +27,7 @@
 # previously-rejected programs, and creates issues for the best new
 # discoveries (max 5 per run).
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"58a2dac085a64dcda551a692dfc41d593bb1bbe1db255d1f156fe58d701da3a0","compiler_version":"v0.56.2"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f4b3aad8263f578290db033c348760d33c3a2d53c5b879c025161b261272f148","compiler_version":"v0.56.2"}
 
 name: "Discover Student Benefits"
 "on":
@@ -656,8 +656,7 @@ jobs:
                   "tavily-mcp"
                 ],
                 "tools": [
-                  "search",
-                  "search_news"
+                  "tavily_search"
                 ],
                 "env": {
                   "TAVILY_API_KEY": "\${TAVILY_API_KEY}"

--- a/.github/workflows/discover-benefits.md
+++ b/.github/workflows/discover-benefits.md
@@ -31,7 +31,7 @@ mcp-servers:
     args: ["-y", "tavily-mcp"]
     env:
       TAVILY_API_KEY: "${{ secrets.TAVILY_API_KEY }}"
-    allowed: ["search", "search_news"]
+    allowed: ["tavily_search"]
 
 tools:
   github:

--- a/.github/workflows/discover-events.lock.yml
+++ b/.github/workflows/discover-events.lock.yml
@@ -27,7 +27,7 @@
 # opens PRs for the best new discoveries (max 3 per run). Human approves all
 # changes — nothing merges automatically.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"2c2e2ae680498a5182b3ee6ba227acf8ac84c35f4b996a938726b81b1c827c93","compiler_version":"v0.56.2"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6114ddbb9f3888b0593dc6a0395e9f207262a1d5a278f6632952fa0d195dfa71","compiler_version":"v0.56.2"}
 
 name: "Discover Student Events"
 "on":
@@ -662,8 +662,7 @@ jobs:
                   "tavily-mcp"
                 ],
                 "tools": [
-                  "search",
-                  "search_news"
+                  "tavily_search"
                 ],
                 "env": {
                   "TAVILY_API_KEY": "\${TAVILY_API_KEY}"

--- a/.github/workflows/discover-events.md
+++ b/.github/workflows/discover-events.md
@@ -30,7 +30,7 @@ mcp-servers:
     args: ["-y", "tavily-mcp"]
     env:
       TAVILY_API_KEY: "${{ secrets.TAVILY_API_KEY }}"
-    allowed: ["search", "search_news"]
+    allowed: ["tavily_search"]
 
 tools:
   github:

--- a/.github/workflows/maintain-benefits.lock.yml
+++ b/.github/workflows/maintain-benefits.lock.yml
@@ -27,7 +27,7 @@
 # removes entries for programs that no longer exist. Opens a PR with all
 # changes. Human approves the merge — nothing lands automatically.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e081e702f085b0854a0f86f870499ed81cdb01bd9e8aa5496bd0fd426621c64b","compiler_version":"v0.56.2"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"d265d190dec8689d3127d9de1c3b04842f5051b36e122f8f9475dda09f971e14","compiler_version":"v0.56.2"}
 
 name: "Maintain Benefits"
 "on":
@@ -712,7 +712,7 @@ jobs:
                   "tavily-mcp"
                 ],
                 "tools": [
-                  "search"
+                  "tavily_search"
                 ],
                 "env": {
                   "TAVILY_API_KEY": "\${TAVILY_API_KEY}"

--- a/.github/workflows/maintain-benefits.md
+++ b/.github/workflows/maintain-benefits.md
@@ -31,7 +31,7 @@ mcp-servers:
     args: ["-y", "tavily-mcp"]
     env:
       TAVILY_API_KEY: "${{ secrets.TAVILY_API_KEY }}"
-    allowed: ["search"]
+    allowed: ["tavily_search"]
 
 tools:
   github:


### PR DESCRIPTION
## Summary

The `allowed` filter in the Tavily MCP server config was listing `search` and `search_news`, but `tavily-mcp` exposes tools named `tavily_search`, `tavily_extract`, `tavily_crawl`, etc. The filter matched nothing, so all Tavily tools were silently blocked from the agent.

This was the second half of the Tavily fix (first was the npm package name in #83). With both fixed, the agent should call `tavily_search` correctly.

Updated `allowed: ["tavily_search"]` in all five workflows.

## Test plan

- [ ] Trigger `add-event` — agent calls `tavily_search`, not `web_fetch` on a search URL
- [ ] Trigger `add-benefit` — same

🤖 Generated with [Claude Code](https://claude.com/claude-code)