### PR TITLE
Add grant as event category, unify PAT secret

### DIFF
--- a/.github/workflows/add-event.md
+++ b/.github/workflows/add-event.md
@@ -116,7 +116,7 @@ Using what you learned from the event page, apply this quality bar. Reject if an
 1. **Free or heavily subsidized** — skip if fee >$50 with no scholarship or travel grant pathway
 2. **Open to individual students** — skip if requires a team, startup, or company affiliation
 3. **Credible organizer** — skip if the organizing entity is obscure or unverifiable (well-known company, university, VC firm, or non-profit clears this)
-4. **Genuinely career-altering** — skip if this is not the kind of event a student would name as a turning point (a hackathon with a cash prize, a fellowship with a cohort, a summit with top speakers clears this; a generic webinar does not)
+4. **Genuinely career-altering** — skip if this is not the kind of opportunity a student would name as a turning point (a hackathon with a cash prize, a fellowship with a cohort, a summit with top speakers, or a grant that funds independent work clears this; a generic webinar does not)
 5. **Active and upcoming** — skip if the date has passed, the application deadline has passed, the event is more than 12 months away, or the page is broken or "coming soon"
 
 If invalid, comment on the issue:
@@ -133,7 +133,7 @@ Create a JSON object matching this exact schema:
   "id": "<url-safe-id>",
   "name": "<Official Event Name>",
   "organizer": "<Organizing entity name>",
-  "category": "<one of: hackathon | conference | fellowship | summit | workshop>",
+  "category": "<one of: hackathon | conference | fellowship | summit | workshop | grant>",
   "date": "<YYYY-MM-DD>",
   "date_end": "<YYYY-MM-DD or omit if single-day>",
   "location": "<City, State/Country or omit if fully remote>",
@@ -147,7 +147,7 @@ Create a JSON object matching this exact schema:
 
 Rules:
 - `id`: lowercase, hyphens only, unique, no leading/trailing hyphens (e.g. `mlh-hackcon-2026`); verify the ID doesn't already exist in `events.json`
-- `category`: must be exactly one of `hackathon`, `conference`, `fellowship`, `summit`, `workshop`
+- `category`: must be exactly one of `hackathon`, `conference`, `fellowship`, `summit`, `workshop`, `grant`
 - `why`: write this yourself based on what you learned from the event page — do not copy marketing text verbatim; max 200 chars
 - `remote`: `true` only if the event is fully virtual; `false` for in-person or hybrid
 - `expires`: same as `date_end`, or `date` if the event is a single day

--- a/.github/workflows/discover-events.md
+++ b/.github/workflows/discover-events.md
@@ -107,7 +107,7 @@ For each result from Steps 3 and 4, use `web-fetch` to confirm the event page is
 1. Free or heavily subsidized (travel grants, stipends, or zero cost) — skip if fee >$50 with no scholarship pathway
 2. Open to individual students — skip if requires team, startup, or company affiliation
 3. Credible organizer (well-known company, university, VC firm, or non-profit) — skip if obscure or unverifiable
-4. Genuinely career-altering — skip if not the kind of event a student would name as a turning point
+4. Genuinely career-altering — skip if not the kind of opportunity a student would name as a turning point (a hackathon with a cash prize, a fellowship with a cohort, a summit with top speakers, or a grant that funds independent work clears this; a generic webinar does not)
 5. Concrete date within 12 months and a working application page — skip if date has passed, is >12 months away, or page is broken/"coming soon"
 
 Keep a shortlist of the best candidates across both passes, up to **3 new events**.
@@ -121,7 +121,7 @@ For each candidate on your shortlist, produce a JSON object matching this schema
   "id": "<url-safe-id>",
   "name": "<Official Event Name>",
   "organizer": "<Organizing entity name>",
-  "category": "<one of: hackathon | conference | fellowship | summit | workshop>",
+  "category": "<one of: hackathon | conference | fellowship | summit | workshop | grant>",
   "date": "<YYYY-MM-DD>",
   "date_end": "<YYYY-MM-DD or omit if single-day>",
   "location": "<City, State/Country or omit if fully remote>",
@@ -135,7 +135,7 @@ For each candidate on your shortlist, produce a JSON object matching this schema
 
 Rules:
 - `id`: lowercase, hyphens only, unique, no leading/trailing hyphens (e.g. `mlh-hackcon-2026`)
-- `category`: must be one of `hackathon`, `conference`, `fellowship`, `summit`, `workshop`
+- `category`: must be one of `hackathon`, `conference`, `fellowship`, `summit`, `workshop`, `grant`
 - `why`: write this yourself based on what you learned from the event page — do not copy marketing text verbatim; max 200 chars
 - `remote`: set to `true` only if the event is fully virtual; set to `false` for in-person or hybrid
 - `expires`: same as `date_end`, or `date` if the event is a single day

--- a/.github/workflows/update-gh-aw.yml
+++ b/.github/workflows/update-gh-aw.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install gh-aw ${{ steps.versions.outputs.latest }}
         if: steps.versions.outputs.current != steps.versions.outputs.latest
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
         run: gh extension install github/gh-aw
 
       - name: Recompile all workflows
@@ -43,7 +43,7 @@ jobs:
       - name: Open PR
         if: steps.versions.outputs.current != steps.versions.outputs.latest
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           CURRENT: ${{ steps.versions.outputs.current }}
           LATEST: ${{ steps.versions.outputs.latest }}
         run: |

--- a/event-categories.json
+++ b/event-categories.json
@@ -1,1 +1,1 @@
-["conference", "hackathon", "fellowship", "summit", "workshop"]
+["conference", "grant", "hackathon", "fellowship", "summit", "workshop"]

--- a/events/index.html
+++ b/events/index.html
@@ -34,7 +34,7 @@
             </a>
           </div>
         </div>
-        <p class="subtitle">Hackathons, conferences, and fellowships — curated, not aggregated.</p>
+        <p class="subtitle">Hackathons, grants, fellowships, and conferences — curated, not aggregated.</p>
       </header>
 
       <div class="filter-wrap">


### PR DESCRIPTION
## Summary

- Adds `grant` as a valid event category alongside hackathon, conference, fellowship, summit, workshop
- Updates quality bar in both `add-event` and `discover-events` to explicitly pass grants (funded independent work clears the bar)
- Unifies PAT secret: renames `GH_PAT` → `GH_AW_GITHUB_TOKEN` in `update-gh-aw.yml` so all workflows share one secret and discover-benefits can trigger add-benefit

## Test plan
- [ ] Verify `GH_AW_GITHUB_TOKEN` secret is set in repo settings before merging
- [ ] After merge, confirm `discover-benefits`-created issues trigger `add-benefit`