### PR TITLE
Add Event: Thiel Fellowship

### DIFF
--- a/agent/last-events-submission.json
+++ b/agent/last-events-submission.json
@@ -1,18 +1,18 @@
 {
-  "issue": 89,
-  "title": "[event]: gemini live agent challenge",
-  "timestamp": "2026-03-10T16:52:15.043Z",
+  "issue": 110,
+  "title": "[event]: thiel fellowship",
+  "timestamp": "2026-04-04T04:27:24.937Z",
   "outcome": "accepted",
   "tools": [
-    { "name": "github-issue_read", "summary": "Read issue #89" },
-    { "name": "tavily_search", "query": "Gemini Live Agent Challenge registration apply Google" },
-    { "name": "web_fetch", "url": "https://geminiliveagentchallenge.devpost.com/" },
+    { "name": "github-issue_read", "summary": "Read issue #110" },
+    { "name": "tavily_search", "query": "Thiel Fellowship 2026 applications registration apply" },
+    { "name": "web_fetch", "url": "https://thielfellowship.org/" },
     { "name": "edit", "summary": "Added entry to events.json" }
   ],
   "event": {
-    "name": "Gemini Live Agent Challenge",
-    "category": "hackathon",
-    "date": "2026-02-16",
-    "organizer": "Google"
+    "name": "Thiel Fellowship",
+    "category": "fellowship",
+    "date": "2026-04-04",
+    "organizer": "Thiel Foundation"
   }
 }

--- a/events.json
+++ b/events.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "thiel-fellowship-2026",
+    "name": "Thiel Fellowship",
+    "organizer": "Thiel Foundation",
+    "category": "fellowship",
+    "date": "2026-04-04",
+    "location": "San Francisco, CA",
+    "remote": false,
+    "eligibility": "Young people age 22 or younger building new ventures",
+    "why": "$200,000 over two years to skip college and build something new. Access to Peter Thiel's network of founders, investors, and scientists in Silicon Valley.",
+    "link": "https://thielfellowship.org/",
+    "expires": "2027-04-04"
+  },
+  {
     "id": "apple-aiml-residency-2026",
     "name": "Apple AIML Residency 2026",
     "organizer": "Apple",


### PR DESCRIPTION
**Category:** fellowship
**Date:** 2026-04-04
**Organizer:** Thiel Foundation
**Link:** https://thielfellowship.org/

$200,000 over two years to skip college and build something new. Access to Peter Thiel's network of founders, investors, and scientists in Silicon Valley.

---

Closes #110




> Generated by [Add Event](https://github.com/student-benefits/student-benefits.github.io/actions/runs/23971269129) for issue #110 · [◷](https://github.com/search?q=repo%3Astudent-benefits%2Fstudent-benefits.github.io+%22gh-aw-workflow-id%3A+add-event%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Add Event, engine: copilot, model: claude-sonnet-4, id: 23971269129, workflow_id: add-event, run: https://github.com/student-benefits/student-benefits.github.io/actions/runs/23971269129 -->

<!-- gh-aw-workflow-id: add-event -->