### PR TITLE
Lift repo to standard: LICENSE, badged README, more topics

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jonas Neves
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Student Benefits Hub
 
-A student discounts directory where Grant, an AI agent, searches the web each week for new benefits. **[→ student-benefits.github.io](https://student-benefits.github.io)**
+**A community-curated directory of student discounts and free tiers, kept current by an AI agent.**
+
+Grant searches the web every week for new programs, validates community submissions opened as issues, and audits link health. Humans approve every merge. **[→ student-benefits.github.io](https://student-benefits.github.io)**
+
+[![Live](https://img.shields.io/badge/live-student--benefits.github.io-blue)](https://student-benefits.github.io)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
+[![Add Benefit](https://github.com/student-benefits/student-benefits.github.io/actions/workflows/add-benefit.lock.yml/badge.svg)](https://github.com/student-benefits/student-benefits.github.io/actions/workflows/add-benefit.lock.yml)
 
 ---
 
 ## How it works
 
-Content enters through multiple paths. Humans submit issues; Grant validates and opens a PR. A separate discover-benefits workflow searches the web weekly and opens issues for new programs. A discover-events workflow finds upcoming student events and creates PRs, removing expired entries automatically. A human reviews and merges. Grant cannot publish directly. The merge is the trust boundary.
+Content enters through multiple paths. Humans submit issues; Grant validates and opens a PR. A separate `discover-benefits` workflow searches the web weekly and opens issues for new programs. A `discover-events` workflow finds upcoming student events and creates PRs, removing expired entries automatically. A `maintain-benefits` workflow audits link health every Sunday. A human reviews and merges. Grant cannot publish directly. The merge is the trust boundary.
 
 The **[/agent/](https://student-benefits.github.io/agent/)** page exposes Grant's run log, tool trace, and architecture so the system can be understood and replicated.
 
@@ -28,4 +34,4 @@ The **[/agent/](https://student-benefits.github.io/agent/)** page exposes Grant'
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Add MIT `LICENSE` (README claimed MIT but the file was missing).
- README now leads with a bold core-value sentence above the explainer, plus Live / License / Add Benefit workflow status badges (matching the convention used by `better-robotics` / `radchat-demo`).
- Repo metadata: added discoverability topics — `agentic-workflows`, `gh-aw`, `community-curated`, `claude`, `student-discounts` (already applied directly to the repo).

## Why

Standardizes this repo against the conventions used across `jonasneves/*` so the README, About metadata, and topics tell the same story at a glance.

## Test plan

- [ ] Render the README on github.com and confirm badges resolve (Live, License, Add Benefit workflow)
- [ ] Confirm topics show under About on the repo home