### PR TITLE
Reframe README lead as agent-as-headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Student Benefits Hub
 
-**A production AI agent (Claude) curating a public directory of student discounts.**
+**Grant — a production AI agent powered by Claude — curates a public directory of student discounts.**
 
 Grant discovers new programs each week, validates community submissions opened as issues, and audits link health. Humans approve every merge — the merge is the trust boundary. Run logs and tool traces are open. **[→ student-benefits.github.io](https://student-benefits.github.io)**
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Student Benefits Hub
 
-**A community-curated directory of student discounts and free tiers, kept current by an AI agent.**
+**A production AI agent (Claude) curating a public directory of student discounts.**
 
-Grant searches the web every week for new programs, validates community submissions opened as issues, and audits link health. Humans approve every merge. **[→ student-benefits.github.io](https://student-benefits.github.io)**
+Grant discovers new programs each week, validates community submissions opened as issues, and audits link health. Humans approve every merge — the merge is the trust boundary. Run logs and tool traces are open. **[→ student-benefits.github.io](https://student-benefits.github.io)**
 
 [![Live](https://img.shields.io/badge/live-student--benefits.github.io-blue)](https://student-benefits.github.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)


### PR DESCRIPTION
## Summary

Aligns the README's lead sentence with the new repo About: leads with the production AI agent (Claude) and names the human-in-the-loop trust boundary, instead of framing the project as a directory that happens to use an agent.

## Why

The repo About was just updated to lead with the agent-and-oversight framing — the README should tell the same story at first glance.