### PR TITLE
Use neevs.io as the footer credit

### DIFF
--- a/benefits/index.html
+++ b/benefits/index.html
@@ -58,7 +58,7 @@
 
       <footer>
         <p>
-          Built by <a href="https://github.com/jonasneves" target="_blank" rel="noopener noreferrer">jonasneves</a>
+          <a href="https://neevs.io" target="_blank" rel="noopener noreferrer">neevs.io</a>
         </p>
       </footer>
     </div>

--- a/events/index.html
+++ b/events/index.html
@@ -52,7 +52,7 @@
       </div>
 
       <footer>
-        <p>Built by <a href="https://github.com/jonasneves" target="_blank" rel="noopener noreferrer">jonasneves</a></p>
+        <p><a href="https://neevs.io" target="_blank" rel="noopener noreferrer">neevs.io</a></p>
       </footer>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Replaces "Built by jonasneves" (linking to a GitHub profile) with a plain `neevs.io` link in the footer of `benefits/` and `events/`. Aligns the public-facing credit with the brand surface used across the rest of `jonasneves/*` repos.

The agent page footer is intentionally different ("Grant is open source. Read the workflows…") and is left alone.

## Test plan

- [ ] Open `/benefits/` and `/events/` and confirm the footer shows `neevs.io` linking to https://neevs.io