### PR TITLE
Switch footer credit to neves.cloud

### DIFF
--- a/benefits/index.html
+++ b/benefits/index.html
@@ -58,7 +58,7 @@
 
       <footer>
         <p>
-          <a href="https://neevs.io" target="_blank" rel="noopener noreferrer">neevs.io</a>
+          by <a href="https://neves.cloud" target="_blank" rel="noopener noreferrer">neves.cloud</a>
         </p>
       </footer>
     </div>

--- a/events/index.html
+++ b/events/index.html
@@ -52,7 +52,7 @@
       </div>
 
       <footer>
-        <p><a href="https://neevs.io" target="_blank" rel="noopener noreferrer">neevs.io</a></p>
+        <p>by <a href="https://neves.cloud" target="_blank" rel="noopener noreferrer">neves.cloud</a></p>
       </footer>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Two changes to the footer on `benefits/` and `events/`:
- Point at `neves.cloud` (was `neevs.io` from the prior PR)
- Prefix with `by ` so the link reads as attribution rather than a standalone CTA — the existing footer link styling (`shared.css:138-144`, indigo-400 with underline) is designed for an inline link inside a sentence

The `/agent/` page footer is left untouched (it's a custom message about Grant being open source).

## Test plan

- [ ] Open `/benefits/` and `/events/` and confirm the footer reads `by neves.cloud` with the link pointing at https://neves.cloud