### PR TITLE
Quiet footer credit (agora style)

### DIFF
--- a/benefits/index.html
+++ b/benefits/index.html
@@ -56,11 +56,7 @@
         </div>
       </div>
 
-      <footer>
-        <p>
-          by <a href="https://neves.cloud" target="_blank" rel="noopener noreferrer">neves.cloud</a>
-        </p>
-      </footer>
+      <footer>neves.cloud</footer>
     </div>
   </div>
 

--- a/events/index.html
+++ b/events/index.html
@@ -51,9 +51,7 @@
         </div>
       </div>
 
-      <footer>
-        <p>by <a href="https://neves.cloud" target="_blank" rel="noopener noreferrer">neves.cloud</a></p>
-      </footer>
+      <footer>neves.cloud</footer>
     </div>
   </div>
 

--- a/shared.css
+++ b/shared.css
@@ -130,18 +130,12 @@ h1 {
 
 footer {
   margin-top: 6rem;
-  padding-top: 2.5rem;
-  border-top: 1px solid var(--slate-800);
+  padding: 2rem;
   text-align: center;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.18);
 }
-footer p { color: var(--slate-500); font-size: 0.875rem; }
-footer a {
-  color: var(--indigo-400);
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  transition: color var(--dur-normal);
-}
-footer a:hover { color: var(--indigo-300); }
 
 .header-row {
   display: flex;


### PR DESCRIPTION
## Summary

Per follow-up: the link-styled footer read as a CTA. Re-styled to match the agora reference (https://neevs.io/agora/) — bare text, very small, letterspaced, low-alpha. Quiet brand signature rather than a clickable element.

- `benefits/`, `events/`: footer is now `<footer>neves.cloud</footer>` (no link, no `<p>`)
- `shared.css`: footer rule simplified — 0.62rem, 0.08em letter-spacing, slate-400 at 18% opacity. Removed `footer p` and `footer a` rules since neither tag remains.

The `.site-footer` class on the `/agent/` page is untouched.

## Test plan

- [ ] `/benefits/` and `/events/` show "neves.cloud" as a barely-visible centered signature, no underline, no hover state