### PR TITLE
Fix engine model: claude-sonnet-4.5 (the real one)

### DIFF
--- a/.github/workflows/add-benefit.lock.yml
+++ b/.github/workflows/add-benefit.lock.yml
@@ -25,7 +25,7 @@
 # validates the benefit, checks for duplicates against benefits.json,
 # and creates a PR with the new entry if valid.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"c7d2e2c8f9419adba475933f8c3d075e11288864a3435f74e50beae7f1728b6a","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"392394b657743abf30a6438b59a452a07231e20a4ad308fd79cf32e4be86b9bd","compiler_version":"v0.59.0"}
 
 name: "Add Benefit"
 "on":
@@ -69,7 +69,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "claude-sonnet-4.6"
+          GH_AW_INFO_MODEL: "claude-sonnet-4.5"
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
@@ -831,7 +831,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.6
+          COPILOT_MODEL: claude-sonnet-4.5
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1056,7 +1056,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.6
+          COPILOT_MODEL: claude-sonnet-4.5
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.59.0
@@ -1247,7 +1247,7 @@ jobs:
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/add-benefit"
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "claude-sonnet-4.6"
+      GH_AW_ENGINE_MODEL: "claude-sonnet-4.5"
       GH_AW_WORKFLOW_ID: "add-benefit"
       GH_AW_WORKFLOW_NAME: "Add Benefit"
     outputs:

--- a/.github/workflows/add-benefit.md
+++ b/.github/workflows/add-benefit.md
@@ -9,7 +9,7 @@ strict: false
 
 engine:
   id: copilot
-  model: claude-sonnet-4.6
+  model: claude-sonnet-4.5
 
 on:
   issues:

--- a/.github/workflows/add-event.lock.yml
+++ b/.github/workflows/add-event.lock.yml
@@ -25,7 +25,7 @@
 # validates the event against the quality bar, checks for duplicates against
 # events.json, and creates a PR with the new entry if valid.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"120a9839331fc6878a58c2923215469e967405c2cce42522e01c5a3cb773aa6e","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"43150bb54155a911b6f64557dd43becce5dc048ae3fa7efcc836e353f4a3e8c7","compiler_version":"v0.59.0"}
 
 name: "Add Event"
 "on":
@@ -69,7 +69,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "claude-sonnet-4.6"
+          GH_AW_INFO_MODEL: "claude-sonnet-4.5"
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
@@ -831,7 +831,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.6
+          COPILOT_MODEL: claude-sonnet-4.5
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1056,7 +1056,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.6
+          COPILOT_MODEL: claude-sonnet-4.5
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.59.0
@@ -1247,7 +1247,7 @@ jobs:
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/add-event"
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "claude-sonnet-4.6"
+      GH_AW_ENGINE_MODEL: "claude-sonnet-4.5"
       GH_AW_WORKFLOW_ID: "add-event"
       GH_AW_WORKFLOW_NAME: "Add Event"
     outputs:

--- a/.github/workflows/add-event.md
+++ b/.github/workflows/add-event.md
@@ -9,7 +9,7 @@ strict: false
 
 engine:
   id: copilot
-  model: claude-sonnet-4.6
+  model: claude-sonnet-4.5
 
 on:
   issues:

--- a/.github/workflows/discover-benefits.lock.yml
+++ b/.github/workflows/discover-benefits.lock.yml
@@ -27,7 +27,7 @@
 # previously-rejected programs, and creates issues for the best new
 # discoveries (max 5 per run).
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8c914c6009c74339614e4b814e8a03b3f92c30bd28d8c749829123dc0bdcfb3e","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"60160db4224820016c53e754d9133fe235f9af978b8d424cefb5e520d1b12e90","compiler_version":"v0.59.0"}
 
 name: "Discover Student Benefits"
 "on":
@@ -63,7 +63,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "claude-sonnet-4.6"
+          GH_AW_INFO_MODEL: "claude-sonnet-4.5"
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
@@ -696,7 +696,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.6
+          COPILOT_MODEL: claude-sonnet-4.5
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -920,7 +920,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.6
+          COPILOT_MODEL: claude-sonnet-4.5
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.59.0
@@ -1087,7 +1087,7 @@ jobs:
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/discover-benefits"
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "claude-sonnet-4.6"
+      GH_AW_ENGINE_MODEL: "claude-sonnet-4.5"
       GH_AW_WORKFLOW_ID: "discover-benefits"
       GH_AW_WORKFLOW_NAME: "Discover Student Benefits"
     outputs:

--- a/.github/workflows/discover-benefits.md
+++ b/.github/workflows/discover-benefits.md
@@ -11,7 +11,7 @@ strict: false
 
 engine:
   id: copilot
-  model: claude-sonnet-4.6
+  model: claude-sonnet-4.5
 
 on:
   schedule:

--- a/.github/workflows/discover-events.lock.yml
+++ b/.github/workflows/discover-events.lock.yml
@@ -27,7 +27,7 @@
 # opens PRs for the best new discoveries (max 3 per run). Human approves all
 # changes — nothing merges automatically.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"55a4eb9916ee37ee05c6686b1ae0ebb81f8af2ee5db58c7283518561fc33a9f7","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1e8603cc059e0216b2df87fe43493ca7a3950850676265801b755f042d431d4d","compiler_version":"v0.59.0"}
 
 name: "Discover Student Events"
 "on":
@@ -63,7 +63,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "claude-sonnet-4.6"
+          GH_AW_INFO_MODEL: "claude-sonnet-4.5"
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
@@ -702,7 +702,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.6
+          COPILOT_MODEL: claude-sonnet-4.5
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -927,7 +927,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.6
+          COPILOT_MODEL: claude-sonnet-4.5
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.59.0
@@ -1114,7 +1114,7 @@ jobs:
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/discover-events"
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "claude-sonnet-4.6"
+      GH_AW_ENGINE_MODEL: "claude-sonnet-4.5"
       GH_AW_WORKFLOW_ID: "discover-events"
       GH_AW_WORKFLOW_NAME: "Discover Student Events"
     outputs:

--- a/.github/workflows/discover-events.md
+++ b/.github/workflows/discover-events.md
@@ -11,7 +11,7 @@ strict: false
 
 engine:
   id: copilot
-  model: claude-sonnet-4.6
+  model: claude-sonnet-4.5
 
 on:
   schedule:

--- a/.github/workflows/maintain-benefits.lock.yml
+++ b/.github/workflows/maintain-benefits.lock.yml
@@ -27,7 +27,7 @@
 # removes entries for programs that no longer exist. Opens a PR with all
 # changes. Human approves the merge — nothing lands automatically.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"58a552ec1cc8f240587fa73977b8d283d8139ab77fc5c7035a0f7e4930449e75","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6eef01633b8dd31dd9dd6dc16c9df561bdc82c3f6f60faafa795069fa6faec2b","compiler_version":"v0.59.0"}
 
 name: "Maintain Benefits"
 "on":
@@ -63,7 +63,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "claude-sonnet-4.6"
+          GH_AW_INFO_MODEL: "claude-sonnet-4.5"
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
@@ -752,7 +752,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.6
+          COPILOT_MODEL: claude-sonnet-4.5
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -977,7 +977,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.6
+          COPILOT_MODEL: claude-sonnet-4.5
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.59.0
@@ -1164,7 +1164,7 @@ jobs:
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/maintain-benefits"
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "claude-sonnet-4.6"
+      GH_AW_ENGINE_MODEL: "claude-sonnet-4.5"
       GH_AW_WORKFLOW_ID: "maintain-benefits"
       GH_AW_WORKFLOW_NAME: "Maintain Benefits"
     outputs:

--- a/.github/workflows/maintain-benefits.md
+++ b/.github/workflows/maintain-benefits.md
@@ -11,7 +11,7 @@ strict: false
 
 engine:
   id: copilot
-  model: claude-sonnet-4.6
+  model: claude-sonnet-4.5
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

PR #136 bumped to `claude-sonnet-4.6`, but that's still rejected by Copilot CLI as `model_not_supported`. Verified empirically by re-bouncing the label on #125 — same error.

Queried the local Copilot CLI directly for its accepted model list:

```
claude-sonnet-4.5
claude-haiku-4.5
claude-opus-4.5
```

Copilot's model registry only goes up to 4.5 today. The earlier research that suggested 4.6 was citing an Anthropic API blog post, which uses a different identifier scheme than Copilot CLI's accepted values.

## Test plan

- [ ] Merge
- [ ] Bounce `new-benefit` label on #125, confirm agent now completes (no `model_not_supported` error)
- [ ] Run `gh workflow run discover-benefits.lock.yml` and confirm scheduled flow works