### PR TITLE
Remove engine.model — let Copilot auto-route

### DIFF
--- a/.github/workflows/add-benefit.lock.yml
+++ b/.github/workflows/add-benefit.lock.yml
@@ -25,7 +25,7 @@
 # validates the benefit, checks for duplicates against benefits.json,
 # and creates a PR with the new entry if valid.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"392394b657743abf30a6438b59a452a07231e20a4ad308fd79cf32e4be86b9bd","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"5d02683cc97fe19b7fa69ae9a33d987ce5af4064d34b844dc968817bd5eef963","compiler_version":"v0.59.0"}
 
 name: "Add Benefit"
 "on":
@@ -69,7 +69,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "claude-sonnet-4.5"
+          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
@@ -831,7 +831,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.5
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1056,7 +1056,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.5
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || '' }}
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.59.0
@@ -1247,7 +1247,6 @@ jobs:
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/add-benefit"
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "claude-sonnet-4.5"
       GH_AW_WORKFLOW_ID: "add-benefit"
       GH_AW_WORKFLOW_NAME: "Add Benefit"
     outputs:

--- a/.github/workflows/add-benefit.md
+++ b/.github/workflows/add-benefit.md
@@ -9,7 +9,6 @@ strict: false
 
 engine:
   id: copilot
-  model: claude-sonnet-4.5
 
 on:
   issues:

--- a/.github/workflows/add-event.lock.yml
+++ b/.github/workflows/add-event.lock.yml
@@ -25,7 +25,7 @@
 # validates the event against the quality bar, checks for duplicates against
 # events.json, and creates a PR with the new entry if valid.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"43150bb54155a911b6f64557dd43becce5dc048ae3fa7efcc836e353f4a3e8c7","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6e854ba6e01ea9e9346c70d8d3d90d50c0c34aa56b6d94964e1b5ac1709eba37","compiler_version":"v0.59.0"}
 
 name: "Add Event"
 "on":
@@ -69,7 +69,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "claude-sonnet-4.5"
+          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
@@ -831,7 +831,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.5
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1056,7 +1056,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.5
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || '' }}
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.59.0
@@ -1247,7 +1247,6 @@ jobs:
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/add-event"
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "claude-sonnet-4.5"
       GH_AW_WORKFLOW_ID: "add-event"
       GH_AW_WORKFLOW_NAME: "Add Event"
     outputs:

--- a/.github/workflows/add-event.md
+++ b/.github/workflows/add-event.md
@@ -9,7 +9,6 @@ strict: false
 
 engine:
   id: copilot
-  model: claude-sonnet-4.5
 
 on:
   issues:

--- a/.github/workflows/discover-benefits.lock.yml
+++ b/.github/workflows/discover-benefits.lock.yml
@@ -27,7 +27,7 @@
 # previously-rejected programs, and creates issues for the best new
 # discoveries (max 5 per run).
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"60160db4224820016c53e754d9133fe235f9af978b8d424cefb5e520d1b12e90","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a010ce550b231d0707b055a3627944914e8493d514beeadb1443864087420541","compiler_version":"v0.59.0"}
 
 name: "Discover Student Benefits"
 "on":
@@ -63,7 +63,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "claude-sonnet-4.5"
+          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
@@ -696,7 +696,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.5
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -920,7 +920,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.5
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || '' }}
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.59.0
@@ -1087,7 +1087,6 @@ jobs:
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/discover-benefits"
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "claude-sonnet-4.5"
       GH_AW_WORKFLOW_ID: "discover-benefits"
       GH_AW_WORKFLOW_NAME: "Discover Student Benefits"
     outputs:

--- a/.github/workflows/discover-benefits.md
+++ b/.github/workflows/discover-benefits.md
@@ -11,7 +11,6 @@ strict: false
 
 engine:
   id: copilot
-  model: claude-sonnet-4.5
 
 on:
   schedule:

--- a/.github/workflows/discover-events.lock.yml
+++ b/.github/workflows/discover-events.lock.yml
@@ -27,7 +27,7 @@
 # opens PRs for the best new discoveries (max 3 per run). Human approves all
 # changes — nothing merges automatically.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1e8603cc059e0216b2df87fe43493ca7a3950850676265801b755f042d431d4d","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"9f98f25c3817cab3d46f178957120f6fcfd90f0d65836d8c3537e144d7e07c46","compiler_version":"v0.59.0"}
 
 name: "Discover Student Events"
 "on":
@@ -63,7 +63,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "claude-sonnet-4.5"
+          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
@@ -702,7 +702,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.5
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -927,7 +927,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.5
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || '' }}
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.59.0
@@ -1114,7 +1114,6 @@ jobs:
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/discover-events"
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "claude-sonnet-4.5"
       GH_AW_WORKFLOW_ID: "discover-events"
       GH_AW_WORKFLOW_NAME: "Discover Student Events"
     outputs:

--- a/.github/workflows/discover-events.md
+++ b/.github/workflows/discover-events.md
@@ -11,7 +11,6 @@ strict: false
 
 engine:
   id: copilot
-  model: claude-sonnet-4.5
 
 on:
   schedule:

--- a/.github/workflows/maintain-benefits.lock.yml
+++ b/.github/workflows/maintain-benefits.lock.yml
@@ -27,7 +27,7 @@
 # removes entries for programs that no longer exist. Opens a PR with all
 # changes. Human approves the merge — nothing lands automatically.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6eef01633b8dd31dd9dd6dc16c9df561bdc82c3f6f60faafa795069fa6faec2b","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a5a187f882ae629347399b0be0d6e0758f9534a2212c9574ac105fe50a806306","compiler_version":"v0.59.0"}
 
 name: "Maintain Benefits"
 "on":
@@ -63,7 +63,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "claude-sonnet-4.5"
+          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
@@ -752,7 +752,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.5
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -977,7 +977,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-sonnet-4.5
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || '' }}
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.59.0
@@ -1164,7 +1164,6 @@ jobs:
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/maintain-benefits"
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "claude-sonnet-4.5"
       GH_AW_WORKFLOW_ID: "maintain-benefits"
       GH_AW_WORKFLOW_NAME: "Maintain Benefits"
     outputs:

--- a/.github/workflows/maintain-benefits.md
+++ b/.github/workflows/maintain-benefits.md
@@ -11,7 +11,6 @@ strict: false
 
 engine:
   id: copilot
-  model: claude-sonnet-4.5
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

Pinning specific model identifiers (`claude-sonnet-4`, `claude-sonnet-4.6`, `claude-sonnet-4.5`) all hit `model_not_supported` in CI. The runner's auth context (`COPILOT_GITHUB_TOKEN` derived from `GITHUB_TOKEN`) doesn't carry the same model entitlements as a personal Copilot Pro subscription.

GitHub Copilot CLI added auto model selection on 2026-04-17. Dropping the `model:` field lets it route to whatever the runner's auth context can actually use. The compiled lock file still reads from a `GH_AW_MODEL_AGENT_COPILOT` repo variable if you want to pin a model later, but the default empty value routes through auto.

## Test plan

- [ ] Merge
- [ ] Bounce `new-benefit` label on #125 — confirm agent completes (no `model_not_supported`)
- [ ] `gh workflow run discover-benefits.lock.yml` — confirm scheduled flow works

Refs: https://github.blog/changelog/2026-04-17-github-copilot-cli-now-supports-copilot-auto-model-selection/