### PR TITLE
Drop AI provider mentions from public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Student Benefits Hub
 
-**Grant — a production AI agent powered by Claude — curates a public directory of student discounts.**
+**Grant — a production AI agent — curates a public directory of student discounts.**
 
 Grant discovers new programs each week, validates community submissions opened as issues, and audits link health. Humans approve every merge — the merge is the trust boundary. Run logs and tool traces are open. **[→ student-benefits.github.io](https://student-benefits.github.io)**
 

--- a/agent/index.html
+++ b/agent/index.html
@@ -25,7 +25,7 @@
 
   <section class="identity">
     <h1 class="identity-name">Grant</h1>
-    <p class="identity-role">AI agent · <a href="https://claude.ai" target="_blank" rel="noopener noreferrer">Claude Sonnet 4</a> · Student Benefits Hub</p>
+    <p class="identity-role">AI agent · Student Benefits Hub</p>
     <p class="identity-desc">
       Grant is an AI agent that curates this directory by verifying submissions, searching the web for new student programs, and opening pull requests. It runs on a schedule to discover and add benefits without waiting for a human to suggest them. A human reviews and merges every PR — Grant handles correctness, the reviewer exercises judgment.
     </p>
@@ -55,7 +55,7 @@
         <div class="arch-node-wrap">
           <button class="arch-node arch-node--grant" id="node-grant" aria-expanded="false" aria-controls="panel-grant">
             <span class="arch-node-label">Grant</span>
-            <span class="arch-node-sublabel">Claude Sonnet 4</span>
+            <span class="arch-node-sublabel">orchestrator</span>
           </button>
         </div>
 
@@ -114,7 +114,7 @@
           <p>Two issue-triggered workflows process community submissions. <code>add-benefit</code> fires when an issue is labeled <code>new-benefit</code>; <code>add-event</code> fires when an issue is labeled <code>new-event</code>. Both validate the submission, check for duplicates, and open a PR — or comment and close the issue if the submission doesn't pass.</p>
         </div>
         <div id="panel-grant" class="node-panel" hidden>
-          <p class="node-panel-title">Grant · Claude Sonnet 4</p>
+          <p class="node-panel-title">Grant</p>
           <p>The orchestrator. Grant reads the issue, decides which tools to call, interprets the results, and determines the outcome without human approval of intermediate steps. Its output depends on the workflow and the outcome — a PR, a comment, a closed issue, or a combination. Its instructions are a Markdown file checked into this repository.</p>
         </div>
         <div id="panel-tavily" class="node-panel" hidden>


### PR DESCRIPTION
## Summary

Genericizes the public narrative now that the runtime model has changed (and to stay portable across future swaps):

- README lead no longer says "powered by Claude" — just "production AI agent"
- `/agent/` identity-role drops the model name and link
- `/agent/` architecture sublabel for Grant: `Claude Sonnet 4` → `orchestrator` (matches the descriptive style used by every other sublabel)
- `/agent/` node-panel-title drops the `· Claude Sonnet 4` suffix

Repo About description and topics already updated directly via `gh repo edit` (removed `claude`, `claude-sonnet` topics; About text genericized to match).

Intentionally kept:
- `CLAUDE.md` and `Makefile` `make review` target — about Claude Code as Jonas's authoring tool, not Grant's runtime
- `events.json` Anthropic AI Safety Fellows entry — a real student program, content not narrative
- `discover-events.md` Anthropic news source URL — what the discover agent searches

## Test plan

- [ ] Render `/agent/` and confirm "Grant" appears without the model link/sublabel/suffix
- [ ] Confirm README and About no longer mention Claude