### PR TITLE
Pin Copilot CLI to v1.0.39 (MCP fingerprint regression workaround)

### DIFF
--- a/.github/workflows/add-benefit.lock.yml
+++ b/.github/workflows/add-benefit.lock.yml
@@ -25,7 +25,7 @@
 # validates the benefit, checks for duplicates against benefits.json,
 # and creates a PR with the new entry if valid.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"9a60e598622101b895807780f800576bee38137f2ad370f3bb9ca9ab98969c24","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e6cae9bb8ba378f5eb9fde5024ffc51deb872fcb818e765e9589f865a92abb1c","compiler_version":"v0.59.0"}
 
 name: "Add Benefit"
 "on":
@@ -70,8 +70,8 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
           GH_AW_INFO_MODEL: "gpt-5.4-mini"
-          GH_AW_INFO_VERSION: ""
-          GH_AW_INFO_AGENT_VERSION: "latest"
+          GH_AW_INFO_VERSION: "v1.0.39"
+          GH_AW_INFO_AGENT_VERSION: "v1.0.39"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
           GH_AW_INFO_WORKFLOW_NAME: "Add Benefit"
           GH_AW_INFO_EXPERIMENTAL: "false"
@@ -324,7 +324,7 @@ jobs:
             const { main } = require('/opt/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Install GitHub Copilot CLI
-        run: /opt/gh-aw/actions/install_copilot_cli.sh latest
+        run: /opt/gh-aw/actions/install_copilot_cli.sh v1.0.39
         env:
           GH_HOST: github.com
       - name: Install AWF binary
@@ -1248,6 +1248,7 @@ jobs:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/add-benefit"
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: "gpt-5.4-mini"
+      GH_AW_ENGINE_VERSION: "v1.0.39"
       GH_AW_WORKFLOW_ID: "add-benefit"
       GH_AW_WORKFLOW_NAME: "Add Benefit"
     outputs:

--- a/.github/workflows/add-benefit.md
+++ b/.github/workflows/add-benefit.md
@@ -10,6 +10,7 @@ strict: false
 engine:
   id: copilot
   model: gpt-5.4-mini
+  version: v1.0.39  # pinned: copilot-cli#3162 MCP fingerprint regression in 1.0.42+
 
 on:
   issues:

--- a/.github/workflows/add-event.lock.yml
+++ b/.github/workflows/add-event.lock.yml
@@ -25,7 +25,7 @@
 # validates the event against the quality bar, checks for duplicates against
 # events.json, and creates a PR with the new entry if valid.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"5d27126058a2c33a2a8a842b74cc3f31054b9635f66eccf0f9047f4ae4431dc3","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"d0677a6778368daf7c14237d9277be6d1b894539c36c4368a36eb4f988d7b890","compiler_version":"v0.59.0"}
 
 name: "Add Event"
 "on":
@@ -70,8 +70,8 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
           GH_AW_INFO_MODEL: "gpt-5.4-mini"
-          GH_AW_INFO_VERSION: ""
-          GH_AW_INFO_AGENT_VERSION: "latest"
+          GH_AW_INFO_VERSION: "v1.0.39"
+          GH_AW_INFO_AGENT_VERSION: "v1.0.39"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
           GH_AW_INFO_WORKFLOW_NAME: "Add Event"
           GH_AW_INFO_EXPERIMENTAL: "false"
@@ -324,7 +324,7 @@ jobs:
             const { main } = require('/opt/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Install GitHub Copilot CLI
-        run: /opt/gh-aw/actions/install_copilot_cli.sh latest
+        run: /opt/gh-aw/actions/install_copilot_cli.sh v1.0.39
         env:
           GH_HOST: github.com
       - name: Install AWF binary
@@ -1248,6 +1248,7 @@ jobs:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/add-event"
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: "gpt-5.4-mini"
+      GH_AW_ENGINE_VERSION: "v1.0.39"
       GH_AW_WORKFLOW_ID: "add-event"
       GH_AW_WORKFLOW_NAME: "Add Event"
     outputs:

--- a/.github/workflows/add-event.md
+++ b/.github/workflows/add-event.md
@@ -10,6 +10,7 @@ strict: false
 engine:
   id: copilot
   model: gpt-5.4-mini
+  version: v1.0.39  # pinned: copilot-cli#3162 MCP fingerprint regression in 1.0.42+
 
 on:
   issues:

--- a/.github/workflows/discover-benefits.lock.yml
+++ b/.github/workflows/discover-benefits.lock.yml
@@ -27,7 +27,7 @@
 # previously-rejected programs, and creates issues for the best new
 # discoveries (max 5 per run).
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"053710a3638da0ff391f7818772859a50e2a51c6343762293920e077912a749b","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6865a3237fc2f4616759e85302861095d8a757b2d1c4d81bba6c9f4ad627bf28","compiler_version":"v0.59.0"}
 
 name: "Discover Student Benefits"
 "on":
@@ -64,8 +64,8 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
           GH_AW_INFO_MODEL: "gpt-5.4-mini"
-          GH_AW_INFO_VERSION: ""
-          GH_AW_INFO_AGENT_VERSION: "latest"
+          GH_AW_INFO_VERSION: "v1.0.39"
+          GH_AW_INFO_AGENT_VERSION: "v1.0.39"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
           GH_AW_INFO_WORKFLOW_NAME: "Discover Student Benefits"
           GH_AW_INFO_EXPERIMENTAL: "false"
@@ -297,7 +297,7 @@ jobs:
             const { main } = require('/opt/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Install GitHub Copilot CLI
-        run: /opt/gh-aw/actions/install_copilot_cli.sh latest
+        run: /opt/gh-aw/actions/install_copilot_cli.sh v1.0.39
         env:
           GH_HOST: github.com
       - name: Install AWF binary
@@ -1088,6 +1088,7 @@ jobs:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/discover-benefits"
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: "gpt-5.4-mini"
+      GH_AW_ENGINE_VERSION: "v1.0.39"
       GH_AW_WORKFLOW_ID: "discover-benefits"
       GH_AW_WORKFLOW_NAME: "Discover Student Benefits"
     outputs:

--- a/.github/workflows/discover-benefits.md
+++ b/.github/workflows/discover-benefits.md
@@ -12,6 +12,7 @@ strict: false
 engine:
   id: copilot
   model: gpt-5.4-mini
+  version: v1.0.39  # pinned: copilot-cli#3162 MCP fingerprint regression in 1.0.42+
 
 on:
   schedule:

--- a/.github/workflows/discover-events.lock.yml
+++ b/.github/workflows/discover-events.lock.yml
@@ -27,7 +27,7 @@
 # opens PRs for the best new discoveries (max 3 per run). Human approves all
 # changes — nothing merges automatically.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8c9176018c7faa44a57831408968aac74cba673cdd7429610124fe24232efc2d","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"0e8cca6e94438d5646045bf34c2b92372a65a1ed2d4856e0fe246e31b2f1e736","compiler_version":"v0.59.0"}
 
 name: "Discover Student Events"
 "on":
@@ -64,8 +64,8 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
           GH_AW_INFO_MODEL: "gpt-5.4-mini"
-          GH_AW_INFO_VERSION: ""
-          GH_AW_INFO_AGENT_VERSION: "latest"
+          GH_AW_INFO_VERSION: "v1.0.39"
+          GH_AW_INFO_AGENT_VERSION: "v1.0.39"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
           GH_AW_INFO_WORKFLOW_NAME: "Discover Student Events"
           GH_AW_INFO_EXPERIMENTAL: "false"
@@ -300,7 +300,7 @@ jobs:
             const { main } = require('/opt/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Install GitHub Copilot CLI
-        run: /opt/gh-aw/actions/install_copilot_cli.sh latest
+        run: /opt/gh-aw/actions/install_copilot_cli.sh v1.0.39
         env:
           GH_HOST: github.com
       - name: Install AWF binary
@@ -1115,6 +1115,7 @@ jobs:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/discover-events"
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: "gpt-5.4-mini"
+      GH_AW_ENGINE_VERSION: "v1.0.39"
       GH_AW_WORKFLOW_ID: "discover-events"
       GH_AW_WORKFLOW_NAME: "Discover Student Events"
     outputs:

--- a/.github/workflows/discover-events.md
+++ b/.github/workflows/discover-events.md
@@ -12,6 +12,7 @@ strict: false
 engine:
   id: copilot
   model: gpt-5.4-mini
+  version: v1.0.39  # pinned: copilot-cli#3162 MCP fingerprint regression in 1.0.42+
 
 on:
   schedule:

--- a/.github/workflows/maintain-benefits.lock.yml
+++ b/.github/workflows/maintain-benefits.lock.yml
@@ -27,7 +27,7 @@
 # removes entries for programs that no longer exist. Opens a PR with all
 # changes. Human approves the merge — nothing lands automatically.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1c518120500e16903974be213cd6becf224ac5ee078b7664a14605ce7c3db506","compiler_version":"v0.59.0"}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"c13f96b60165efc31b996f50782ebda02702e3281954f597d1fdc9d3bf1a4d78","compiler_version":"v0.59.0"}
 
 name: "Maintain Benefits"
 "on":
@@ -64,8 +64,8 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
           GH_AW_INFO_MODEL: "gpt-5.4-mini"
-          GH_AW_INFO_VERSION: ""
-          GH_AW_INFO_AGENT_VERSION: "latest"
+          GH_AW_INFO_VERSION: "v1.0.39"
+          GH_AW_INFO_AGENT_VERSION: "v1.0.39"
           GH_AW_INFO_CLI_VERSION: "v0.59.0"
           GH_AW_INFO_WORKFLOW_NAME: "Maintain Benefits"
           GH_AW_INFO_EXPERIMENTAL: "false"
@@ -300,7 +300,7 @@ jobs:
             const { main } = require('/opt/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Install GitHub Copilot CLI
-        run: /opt/gh-aw/actions/install_copilot_cli.sh latest
+        run: /opt/gh-aw/actions/install_copilot_cli.sh v1.0.39
         env:
           GH_HOST: github.com
       - name: Install AWF binary
@@ -1165,6 +1165,7 @@ jobs:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/maintain-benefits"
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: "gpt-5.4-mini"
+      GH_AW_ENGINE_VERSION: "v1.0.39"
       GH_AW_WORKFLOW_ID: "maintain-benefits"
       GH_AW_WORKFLOW_NAME: "Maintain Benefits"
     outputs:

--- a/.github/workflows/maintain-benefits.md
+++ b/.github/workflows/maintain-benefits.md
@@ -12,6 +12,7 @@ strict: false
 engine:
   id: copilot
   model: gpt-5.4-mini
+  version: v1.0.39  # pinned: copilot-cli#3162 MCP fingerprint regression in 1.0.42+
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

Pins Copilot CLI to v1.0.39 in all 5 workflows via `engine.version`.

GitHub Copilot CLI v1.0.42 introduced a strict MCP identity fingerprint check that incorrectly blocks properly-configured MCP servers ([copilot-cli#3162](https://github.com/github/copilot-cli/issues/3162), multiple users reporting, no fix yet).

Symptom: every recent run reported `3 MCP servers were blocked by policy: 'github', 'safeoutputs', 'tavily'`. Grant could validate inputs and edit files locally but couldn't fire safe-outputs to create PRs or comments — green run, no visible output.

The lock files now invoke `install_copilot_cli.sh v1.0.39` instead of `latest`.

## Test plan

- [ ] Merge
- [ ] Bounce `new-benefit` label on #125 — confirm a PR is opened (not just green agent step)
- [ ] `gh workflow run discover-benefits.lock.yml` — confirm the scheduled flow now produces issues

When GitHub fixes #3162, drop `version:` from the engine config and we go back to `latest`.