### PR TITLE
Grant write permissions to Grant workflows

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
-      issues: read
-      pull-requests: read
+      contents: write
+      issues: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
-      issues: read
-      pull-requests: read
+      contents: write
+      issues: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/.github/workflows/discover-benefits.yml
+++ b/.github/workflows/discover-benefits.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      contents: read
-      issues: read
+      contents: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      contents: read
-      issues: read
-      pull-requests: read
+      contents: write
+      issues: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/.github/workflows/maintain-benefits.yml
+++ b/.github/workflows/maintain-benefits.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: read
-      issues: read
-      pull-requests: read
+      contents: write
+      issues: write
+      pull-requests: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary

The first end-to-end test on Claude Code Action surfaced **12 permission denials** in the run log:

```json
{ "type": "result", "subtype": "success", "is_error": false,
  "duration_ms": 89483, "num_turns": 20,
  "total_cost_usd": 0.327, "permission_denials_count": 12 }
```

Grant read the issue, did the validation work, but couldn't open a PR or comment because the workflow's `GITHUB_TOKEN` had only read scopes (and the Claude App's privileged token apparently lacks the broader scopes needed for these operations on this repo).

Granting write on `contents`, `issues`, `pull-requests` to the four Grant workflows that need to create PRs, edit JSON, comment, or open issues. `scout-reddit.yml` already had `contents: write` for state pushes.

## Test plan

- [ ] Merge
- [ ] Bounce `new-benefit` label on #125 → confirm PR opens this time
- [ ] If still hitting denials, the Claude GitHub App may need broader perms (re-install with write scopes)