### PR TITLE
Add --dangerously-skip-permissions for autonomous CI runs

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
-          claude_args: "--model claude-sonnet-4-5"
+          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
           prompt: |
             You process student benefit submissions from GitHub issues. Read issue #${{ github.event.issue.number }}, validate it, and either open a PR adding the benefit or comment explaining why it can't be added.
 

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
-          claude_args: "--model claude-sonnet-4-5"
+          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
           prompt: |
             You process student event submissions from GitHub issues. Read issue #${{ github.event.issue.number }}, validate it against the quality bar, and either open a PR adding the event or comment explaining why it can't be added.
 

--- a/.github/workflows/discover-benefits.yml
+++ b/.github/workflows/discover-benefits.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5"
+          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
           prompt: |
             You proactively discover student benefits not yet in the directory and open GitHub issues for the best finds. The add-benefit workflow will pick them up.
 

--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5"
+          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
           prompt: |
             You discover student events worth a student's time, remove expired entries, and open one PR with both. Today's date is needed in UTC ISO 8601 — derive it.
 

--- a/.github/workflows/maintain-benefits.yml
+++ b/.github/workflows/maintain-benefits.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5"
+          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
           prompt: |
             You audit every entry in `benefits.json` for link health and quality, fix every finding you can, and open a single PR. Findings go directly to a PR — you don't open issues.
 

--- a/.github/workflows/scout-reddit.yml
+++ b/.github/workflows/scout-reddit.yml
@@ -36,7 +36,7 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5"
+          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
           prompt: |
             You scout Reddit weekly for student-benefit signal. Two modes (controlled by env vars):
             - `MODE=discover` — find new student benefits mentioned in Reddit posts (so the maintainer can add them)


### PR DESCRIPTION
## Summary

After granting workflow write permissions, end-to-end runs still showed permission denials in Claude's result JSON:

| Run | Denials | Visible output |
|---|---|---|
| Add Benefit on #125 | 4 | None |
| Discover Benefits | 11 | None |

Root cause: `claude-code-action` runs Claude Code CLI with restrictive default tool permissions. Each new tool use (`Edit`, `Write`, `mcp__github__*`, etc.) requires either explicit `--allowedTools` listing or per-call permission. In non-interactive CI, that means auto-deny.

`--dangerously-skip-permissions` is the standard way to run Claude Code agentically in CI: no per-tool prompts, no auto-deny.

## Why "dangerously" is OK here

Safety comes from elsewhere:
- Workflow runs in an ephemeral GitHub Actions runner (no persistent state)
- Each prompt explicitly scopes which files Grant may edit (e.g. `Only edit benefits.json, agent/last-run.json, agent/rejected.json`)
- Humans review every PR before merge — the merge is the trust boundary

Applied to all 6 workflows using `claude-code-action`.

## Test plan

- [ ] Merge
- [ ] Bounce `new-benefit` label on #125 → confirm `permission_denials_count: 0` and a real PR opens