### PR TITLE
Debug: enable show_full_output on add-benefit.yml

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -25,6 +25,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
           claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
+          show_full_output: "true"  # debug: revert once tool denials are diagnosed
           prompt: |
             You process student benefit submissions from GitHub issues. Read issue #${{ github.event.issue.number }}, validate it, and either open a PR adding the benefit or comment explaining why it can't be added.
 


### PR DESCRIPTION
## Summary

Surfaces Claude's complete tool-call sequence in the workflow log so we can see *which* two operations are still hitting permission denials even with `--dangerously-skip-permissions`. Last run exited at turn 6 with 2 denials and no visible output.

## Caveat

`show_full_output` outputs all of Claude's tool execution results — these logs are publicly visible. Per Anthropic's own docs: only enable for debugging in non-sensitive environments. The logs may surface anything Claude reads (issue body content, file contents). For this repo nothing reaches that bar — but I'll revert this commit once we have what we need.

## Test plan

- [ ] Merge
- [ ] Bounce `new-benefit` label on #125 (or trigger on a fresh discovery issue like #150)
- [ ] Read the run log to find the denied tool calls
- [ ] Open a follow-up PR that addresses the denial root cause AND removes `show_full_output`