### PR TITLE
Use explicit --allowedTools instead of --dangerously-skip-permissions

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -24,8 +24,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
-          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
-          show_full_output: "true"  # debug: revert once tool denials are diagnosed
+          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You process student benefit submissions from GitHub issues. Read issue #${{ github.event.issue.number }}, validate it, and either open a PR adding the benefit or comment explaining why it can't be added.
 

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
-          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
+          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You process student event submissions from GitHub issues. Read issue #${{ github.event.issue.number }}, validate it against the quality bar, and either open a PR adding the event or comment explaining why it can't be added.
 

--- a/.github/workflows/discover-benefits.yml
+++ b/.github/workflows/discover-benefits.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
+          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You proactively discover student benefits not yet in the directory and open GitHub issues for the best finds. The add-benefit workflow will pick them up.
 

--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
+          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You discover student events worth a student's time, remove expired entries, and open one PR with both. Today's date is needed in UTC ISO 8601 — derive it.
 

--- a/.github/workflows/maintain-benefits.yml
+++ b/.github/workflows/maintain-benefits.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
+          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You audit every entry in `benefits.json` for link health and quality, fix every finding you can, and open a single PR. Findings go directly to a PR — you don't open issues.
 

--- a/.github/workflows/scout-reddit.yml
+++ b/.github/workflows/scout-reddit.yml
@@ -36,7 +36,7 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5 --dangerously-skip-permissions"
+          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,Write,Read,WebSearch,WebFetch,Bash(curl:*)'"
           prompt: |
             You scout Reddit weekly for student-benefit signal. Two modes (controlled by env vars):
             - `MODE=discover` — find new student benefits mentioned in Reddit posts (so the maintainer can add them)


### PR DESCRIPTION
## Summary

The debug run on #150 revealed that `--dangerously-skip-permissions` doesn't bypass `claude-code-action`'s gate on `Bash` — Grant's calls to `Bash(gh issue view 150)` hit `"This command requires approval"` and gave up after 13 turns. The action keeps a security boundary on Bash regardless of that flag (sensible — it processes untrusted issue content).

Switching to the canonical pattern from anthropics' own `ci-failure-auto-fix` example: explicit `--allowedTools` listing each tool plus tight Bash patterns.

## Per-workflow allowlists

| Workflow | Tools |
|---|---|
| Grant (5 workflows) | `Edit, MultiEdit, Write, Read, Glob, Grep, LS, WebSearch, WebFetch, Bash(git:*), Bash(gh:*)` |
| scout-reddit | `Edit, Write, Read, WebSearch, WebFetch, Bash(curl:*)` (curl for Discord webhook) |

Also reverts `show_full_output: true` on `add-benefit.yml` — diagnosis is done.

## Test plan

- [ ] Merge
- [ ] Bounce `new-benefit` label on a fresh discovery issue (e.g. #150 Appwrite)
- [ ] Confirm: `permission_denials_count: 0`, real PR opened, comment posted on the issue