### PR TITLE
Add LocalStack, Doppler, Boot.dev to student benefits

### DIFF
--- a/benefits.json
+++ b/benefits.json
@@ -815,12 +815,12 @@
     "popularity": 5
   },
   {
-    "id": "bootdev",
+    "id": "boot-dev",
     "name": "Boot.dev",
     "category": "Learning",
     "offer_type": "free",
     "description": "Free 3 months of backend development curriculum (Python, Go, TypeScript).",
-    "link": "https://education.github.com/pack",
+    "link": "https://www.boot.dev/students",
     "tags": [
       "GitHub Student Pack",
       "Backend",

--- a/benefits.json
+++ b/benefits.json
@@ -784,5 +784,48 @@
       "GitHub Student Pack"
     ],
     "popularity": 5
+  },
+  {
+    "id": "localstack",
+    "name": "LocalStack",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free AWS emulator with all services, 1,000 monthly CI/CD credits via GitHub Student Pack.",
+    "link": "https://www.localstack.cloud/localstack-for-students",
+    "tags": [
+      "AWS",
+      "Cloud",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "doppler",
+    "name": "Doppler",
+    "category": "Security",
+    "offer_type": "free",
+    "description": "Free Team subscription for secrets management while enrolled. Sync environment variables, prevent leaks.",
+    "link": "https://www.doppler.com/secretsops-for-students",
+    "tags": [
+      "Security",
+      "Secrets",
+      "GitHub Student Pack",
+      "DevOps"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "bootdev",
+    "name": "Boot.dev",
+    "category": "Learning",
+    "offer_type": "free",
+    "description": "Free 3 months of backend development curriculum (Python, Go, TypeScript).",
+    "link": "https://education.github.com/pack",
+    "tags": [
+      "GitHub Student Pack",
+      "Backend",
+      "Courses"
+    ],
+    "popularity": 5
   }
 ]


### PR DESCRIPTION
## Summary

Bundles the three remaining add-benefit entries from yesterday's discovery batch into one PR to avoid the sequential-merge conflict loop.

| Benefit | Source issue | Originally PR |
|---|---|---|
| LocalStack | #151 | #159 |
| Doppler | #152 | #160 |
| Boot.dev | #153 | #161 |

Each entry was already validated by Grant in its original add-benefit run. PR #158 (Deepnote) and #157 (Appwrite) from the same batch are already merged.

Closes #151
Closes #152
Closes #153

## Test plan

- [ ] Confirm all three entries appear on student-benefits.github.io after merge