### PR TITLE
Remove stale meta-ai-residency-2026 entry

### DIFF
--- a/events.json
+++ b/events.json
@@ -47,7 +47,7 @@
     "location": "Mountain View, CA",
     "remote": false,
     "eligibility": "Open to all; online attendance is free",
-    "why": "Google's flagship developer conference — free online stream. New APIs and SDKs are announced here first, before documentation catches up.",
+    "why": "Google's flagship developer conference \u2014 free online stream. New APIs and SDKs are announced here first, before documentation catches up.",
     "link": "https://io.google/2026/",
     "expires": "2026-05-20"
   },
@@ -115,7 +115,7 @@
     "location": "San Francisco, CA",
     "remote": false,
     "eligibility": "Undergraduate CS or engineering students worldwide; no company required",
-    "why": "$20k cash + $90k in compute credits to build a self-directed AI project in SF. YC picks 20–50 students; no company or team required.",
+    "why": "$20k cash + $90k in compute credits to build a self-directed AI project in SF. YC picks 20\u201350 students; no company or team required.",
     "link": "https://events.ycombinator.com/summer-grants-26",
     "expires": "2026-08-22"
   },
@@ -129,7 +129,7 @@
     "location": "San Francisco, CA",
     "remote": false,
     "eligibility": "CS undergrads, masters, and PhD students",
-    "why": "Free, in-person, highly selective. Speakers include Sam Altman, Andrej Karpathy, and Andrew Ng — for CS students who want to build AI companies, this is the room.",
+    "why": "Free, in-person, highly selective. Speakers include Sam Altman, Andrej Karpathy, and Andrew Ng \u2014 for CS students who want to build AI companies, this is the room.",
     "link": "https://www.ycombinator.com/blog/ai-startupschool",
     "expires": "2026-06-17"
   },
@@ -145,20 +145,6 @@
     "eligibility": "Master's/PhD graduates, software engineers, academics seeking industry experience",
     "why": "One-year paid residency at Apple working on ML products that impact millions. Residents publish at premier venues like NeurIPS while gaining direct Apple mentor access.",
     "link": "https://machinelearning.apple.com/updates/aiml-residency-program-application-2026",
-    "expires": "2027-06-30"
-  },
-  {
-    "id": "meta-ai-residency-2026",
-    "name": "Meta AI Residency Program 2026",
-    "organizer": "Meta",
-    "category": "fellowship",
-    "date": "2026-07-01",
-    "date_end": "2027-06-30",
-    "location": "Menlo Park, CA",
-    "remote": false,
-    "eligibility": "Technical backgrounds looking to apply to PhD programs; diverse STEM backgrounds welcome",
-    "why": "One-year research training at Meta AI, pairing residents with researchers. Focus on publishing at top conferences (NeurIPS, ICML, ICLR) and open-source impact.",
-    "link": "https://ai.meta.com/join-us/residency-program/",
     "expires": "2027-06-30"
   },
   {
@@ -183,7 +169,7 @@
     "date_end": "2026-11-30",
     "remote": true,
     "eligibility": "Undergrads through professionals worldwide; DC track requires US work authorization",
-    "why": "$15–22k stipend, two-week DC residency, direct mentorship from leading AI governance experts. Past fellows joined CSET, GovAI, and major tech policy shops.",
+    "why": "$15\u201322k stipend, two-week DC residency, direct mentorship from leading AI governance experts. Past fellows joined CSET, GovAI, and major tech policy shops.",
     "link": "https://www.iaps.ai/fellowship",
     "expires": "2026-11-30"
   },


### PR DESCRIPTION
## Summary

Removes `meta-ai-residency-2026` from `events.json`.

## Why

Fact-checked against the live Meta AI Residency page:

> "Applications are now closed. New residents will start in Fall 2023. To apply: The application for the 2023 cohort is now closed."

The page hasn't been updated for the 2026 iteration. There is no current cohort to apply to.

Apple AIML Residency 2026 (also in `events.json`) was checked too and IS active — page from Nov 7, 2025: "The 2026 AIML Residency Program Application is Now Open" — so it stays.

If Meta announces a future cohort, `discover-events` will re-find it on its next run.