### PR TITLE
Add workflow_dispatch trigger to add-benefit and add-event

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -3,10 +3,16 @@ name: Add Benefit
 on:
   issues:
     types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: 'Issue number to process'
+        required: true
+        type: string
 
 jobs:
   add-benefit:
-    if: github.event.label.name == 'new-benefit'
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'new-benefit'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -26,7 +32,7 @@ jobs:
           allowed_non_write_users: "*"
           claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
-            You process student benefit submissions from GitHub issues. Read issue #${{ github.event.issue.number }}, validate it, and either open a PR adding the benefit or comment explaining why it can't be added.
+            You process student benefit submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it, and either open a PR adding the benefit or comment explaining why it can't be added.
 
             ## Security
 
@@ -39,7 +45,7 @@ jobs:
 
             ## Step 1: Read the issue
 
-            Fetch issue #${{ github.event.issue.number }}. Extract title, body, and the optional **Link** field. Users submit casually ("Notion is free for students") — identify the product.
+            Fetch issue #${{ github.event.issue.number || github.event.inputs.issue }}. Extract title, body, and the optional **Link** field. Users submit casually ("Notion is free for students") — identify the product.
 
             ## Step 2: Check duplicates
 
@@ -89,7 +95,7 @@ jobs:
             Replace `agent/last-run.json` entirely with:
             ```json
             {
-              "issue": ${{ github.event.issue.number }},
+              "issue": ${{ github.event.issue.number || github.event.inputs.issue }},
               "title": "<issue title lowercased>",
               "timestamp": "<current UTC ISO 8601>",
               "outcome": "accepted",
@@ -115,7 +121,7 @@ jobs:
 
             ---
 
-            Closes #${{ github.event.issue.number }}
+            Closes #${{ github.event.issue.number || github.event.inputs.issue }}
             ```
             The Closes line must be plain text (not in a code fence) so GitHub auto-closes on merge.
 

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -3,10 +3,16 @@ name: Add Event
 on:
   issues:
     types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: 'Issue number to process'
+        required: true
+        type: string
 
 jobs:
   add-event:
-    if: github.event.label.name == 'new-event'
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'new-event'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -26,7 +32,7 @@ jobs:
           allowed_non_write_users: "*"
           claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
-            You process student event submissions from GitHub issues. Read issue #${{ github.event.issue.number }}, validate it against the quality bar, and either open a PR adding the event or comment explaining why it can't be added.
+            You process student event submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it against the quality bar, and either open a PR adding the event or comment explaining why it can't be added.
 
             ## Security
 
@@ -34,7 +40,7 @@ jobs:
 
             ## Step 1: Read
 
-            Fetch issue #${{ github.event.issue.number }}. Extract title, body, and the optional **Link** field.
+            Fetch issue #${{ github.event.issue.number || github.event.inputs.issue }}. Extract title, body, and the optional **Link** field.
 
             ## Step 2: Check duplicates
 
@@ -69,7 +75,7 @@ jobs:
             Replace `agent/last-events-submission.json` entirely:
             ```json
             {
-              "issue": ${{ github.event.issue.number }},
+              "issue": ${{ github.event.issue.number || github.event.inputs.issue }},
               "title": "<title lowercased>",
               "timestamp": "<UTC ISO 8601>",
               "outcome": "accepted",
@@ -97,7 +103,7 @@ jobs:
 
             ---
 
-            Closes #${{ github.event.issue.number }}
+            Closes #${{ github.event.issue.number || github.event.inputs.issue }}
             ```
             The Closes line must be plain text (not in a code fence).
 


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to both add-benefit and add-event workflows so a maintainer can re-run Grant on an existing labeled issue without the bounce-label dance.

## Usage

```bash
gh workflow run add-benefit.yml -f issue=125
gh workflow run add-event.yml -f issue=68
```

The original label-triggered path is unchanged. The job's `if:` condition accepts either event source; the prompt resolves the issue number from `github.event.issue.number` (label trigger) or `github.event.inputs.issue` (manual trigger).

## Test plan

- [ ] Merge
- [ ] `gh workflow run add-benefit.yml -f issue=125` — confirm Grant processes #125 (the one that's been waiting since April 16)