### PR TITLE
Unblock bot-authored issues in add-benefit and add-event

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
+          allowed_bots: "claude"
           claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You process student benefit submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it, and either open a PR adding the benefit or comment explaining why it can't be added.

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
+          allowed_bots: "claude"
           claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You process student event submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it against the quality bar, and either open a PR adding the event or comment explaining why it can't be added.


### PR DESCRIPTION
## Summary

- `claude-code-action` rejects bot-triggered runs unless `allowed_bots` is set. Error: `Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`
- `discover-benefits` opens issues as `app/claude`, so every `Add Benefit` run from those issues has failed since May 11 (issues #169–#180, 11 stuck candidates).
- Adds `allowed_bots: "claude"` to both `add-benefit.yml` and `add-event.yml`. `add-event.yml` doesn't have a current bot-trigger path but the events discovery workflow is structurally symmetric — kept in sync.

## Test plan

- [ ] Merge.
- [ ] Trigger `Add Benefit` manually against one stuck issue (e.g. #169 Frontend Masters) via `workflow_dispatch`.
- [ ] Confirm a PR is opened with a valid `benefits.json` entry and no permission error in the run log.
- [ ] If green, re-trigger across the remaining 10 stuck issues (or wait for the next Monday cycle to clear them naturally).