### PR TITLE
Frame the directory and clarify the call to contribute

### DIFF
--- a/benefits/index.html
+++ b/benefits/index.html
@@ -26,7 +26,7 @@
             </a>
           </div>
           <div class="header-actions">
-            <a href="https://github.com/student-benefits/student-benefits.github.io/issues/new?template=new-benefit.yml" target="_blank" rel="noopener noreferrer" class="contribute-banner">
+            <a href="https://github.com/student-benefits/student-benefits.github.io/issues/new?template=new-benefit.yml" target="_blank" rel="noopener noreferrer" class="contribute-banner" aria-label="Suggest a missing benefit">
               <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
               Suggest a missing one
             </a>

--- a/benefits/index.html
+++ b/benefits/index.html
@@ -28,10 +28,11 @@
           <div class="header-actions">
             <a href="https://github.com/student-benefits/student-benefits.github.io/issues/new?template=new-benefit.yml" target="_blank" rel="noopener noreferrer" class="contribute-banner">
               <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
-              Submit a benefit
+              Suggest a missing one
             </a>
           </div>
         </div>
+        <p class="subtitle">Free and discounted programs for students. Click any card to claim.</p>
 
         <div role="search" class="search-wrap">
           <svg class="search-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">

--- a/events/events.css
+++ b/events/events.css
@@ -1,6 +1,5 @@
 /* Header */
 .site-id { margin-bottom: 0.4rem; }
-.subtitle { font-size: 0.9375rem; color: var(--slate-400); line-height: 1.5; margin-top: 0.375rem; }
 
 /* Filters */
 .filter-wrap { margin: 1.5rem 0; }

--- a/events/index.html
+++ b/events/index.html
@@ -30,7 +30,7 @@
           <div class="header-actions">
             <a href="https://github.com/student-benefits/student-benefits.github.io/issues/new?template=new-event.yml" target="_blank" rel="noopener noreferrer" class="contribute-banner">
               <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
-              Submit an event
+              Suggest a missing one
             </a>
           </div>
         </div>

--- a/events/index.html
+++ b/events/index.html
@@ -28,7 +28,7 @@
             </a>
           </div>
           <div class="header-actions">
-            <a href="https://github.com/student-benefits/student-benefits.github.io/issues/new?template=new-event.yml" target="_blank" rel="noopener noreferrer" class="contribute-banner">
+            <a href="https://github.com/student-benefits/student-benefits.github.io/issues/new?template=new-event.yml" target="_blank" rel="noopener noreferrer" class="contribute-banner" aria-label="Suggest a missing event">
               <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
               Suggest a missing one
             </a>

--- a/shared.css
+++ b/shared.css
@@ -77,6 +77,8 @@ header { margin-bottom: 2rem; }
 }
 .site-alt:hover { color: #fff; }
 
+.subtitle { font-size: 0.9375rem; color: var(--slate-400); line-height: 1.5; margin-top: 0.375rem; }
+
 .grant-badge {
   display: inline-flex;
   align-items: center;

--- a/shared.css
+++ b/shared.css
@@ -77,7 +77,7 @@ header { margin-bottom: 2rem; }
 }
 .site-alt:hover { color: #fff; }
 
-.subtitle { font-size: 0.9375rem; color: var(--slate-400); line-height: 1.5; margin-top: 0.375rem; }
+.subtitle { font-size: 0.9375rem; color: var(--slate-400); line-height: 1.5; margin: 0.375rem 0 1.5rem; }
 
 .grant-badge {
   display: inline-flex;


### PR DESCRIPTION
## Summary

- ~3/7 recent human-opened issues misread "Submit a benefit" as a request form for personal access (#126, #128, #123). The button shares its noun with the cards, and the landing page never declares what the site *is*.
- Subtitle on benefits page: *"Free and discounted programs for students. Click any card to claim."* Frames the site as a directory before the eye reaches the button.
- Both buttons: `Submit a benefit` / `Submit an event` → `Suggest a missing one`. Removes the request-form reading; matches the directory frame.
- Promote `.subtitle` to `shared.css` so both pages share the rule (was scoped to `events/events.css`).

## Test plan

- [ ] Verify benefits page renders the subtitle under the header on desktop and mobile widths.
- [ ] Verify both buttons read "Suggest a missing one".
- [ ] Verify events page subtitle still renders (unchanged copy, same `.subtitle` class).
- [ ] After merge, watch the next ~4 weeks of human-opened issues for whether the request-form pattern disappears.