### PR TITLE
Fix TryHackMe broken link

### DIFF
--- a/benefits.json
+++ b/benefits.json
@@ -539,7 +539,7 @@
     "category": "Learning",
     "offer_type": "discount",
     "description": "20% off annual subscription. Beginner-friendly cybersecurity training with guided learning paths and virtual labs.",
-    "link": "https://help.tryhackme.com/en/articles/6494960-student-discount",
+    "link": "https://tryhackme.com/discounts",
     "tags": [
       "Cybersecurity",
       "Learning",


### PR DESCRIPTION
## Summary

`help.tryhackme.com/en/articles/6494960-student-discount` returns **301 to /community** — the help article was removed. Repointing to `tryhackme.com/discounts`, the canonical student-discount landing page (HTTP 200, lists the student offer directly).

Introduced by the May 10 maintenance run (PR #168) when it changed the link from `/pricing` to a help-article URL.

## Test plan

- [ ] Click the TryHackMe card on the live site and confirm it loads the discounts page.