### PR TITLE
Forbid help-article URLs as benefit links

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -89,6 +89,8 @@ jobs:
 
             Prefer the user-provided link; otherwise find the official student signup URL.
 
+            `link` MUST be the program's own signup, pricing, or program-overview page (e.g. `/students`, `/education`, `/edu`, `/pricing`). Never use a help/docs/support article URL — subdomains `help.`/`support.`/`docs.` or paths containing `/articles/`. Those are documentation, not signup destinations. If only a help-article URL is available, WebSearch the underlying program page and use that instead.
+
             ## Step 5: Write files
 
             Append the entry to `benefits.json` (preserve 2-space indent, trailing newline).

--- a/.github/workflows/maintain-benefits.yml
+++ b/.github/workflows/maintain-benefits.yml
@@ -45,7 +45,7 @@ jobs:
             For each benefit, apply the bar. Only flag unambiguous violations; if uncertain, skip.
 
             1. **Specific offer**: description must contain a percentage, dollar/credit amount, plan name, or duration. Flag generic descriptions.
-            2. **Direct signup link**: flag only if path is exactly `/` or `/home`, or subdomain is `support.`/`docs.`/`help.`/`blog.` AND path lacks `/edu`/`/education`/`/student`/`/students`/`/enrollment`. URL structure only — don't read page content.
+            2. **Direct signup link**: flag if path is exactly `/` or `/home`, or if subdomain is `support.`/`docs.`/`help.`/`blog.`, or if path contains `/articles/`. Help/docs/support articles are documentation, not signup — even when the article title mentions students. URL structure only — don't read page content.
             3. **Self-serve**: flag if description contains "through your university", "ask your institution", or "contact IT".
             4. **Offer type accuracy**: flag clear mismatches — description says "% off" / "discount" but `offer_type: free`; or description says "free" but `offer_type: discount`.
             5. **Description length**: flag `description` exceeding 120 characters.


### PR DESCRIPTION
## Summary

Two real incidents this session traced to the same pattern: the workflows kept choosing help/docs/support article URLs as the canonical \`link\`.

- **TryHackMe** (#185): \`help.tryhackme.com/en/articles/6494960-student-discount\` was 301'd to /community. The help article had been deleted, leaving the directory with a dead link.
- **Jitter** (PR #196): \`help.jitter.video/en/articles/6545337-jitter-for-education\` returned 404 outright when the validator picked it. Repaired pre-merge.

### Root cause

\`maintain-benefits\` had an explicit exemption: help/docs/support subdomains were *only* flagged when the URL path **lacked** student/edu keywords. Both broken URLs above had "student-discount" or "education" in the path — they were exempted. The exemption was meant to be lenient toward articles about students, but the article title isn't the signup destination.

\`add-benefit\` had no constraint at all on what kind of URL \`link\` could point to.

### Change

- \`maintain-benefits\` Step 3.2: help/docs/support subdomains and \`/articles/\` paths are always flagged. No path-content exemption.
- \`add-benefit\` Step 4: explicit rule that \`link\` must be a signup/pricing/program-overview page, never a help-article URL.

## Test plan

- [ ] Next Sunday \`maintain-benefits\` run: confirm it doesn't choose help-article URLs as replacements for broken links.
- [ ] Next bot-discovered or human-submitted issue routed through \`add-benefit\`: confirm \`link\` lands on a non-help URL.