### PR TITLE
Drop stale Add Benefit badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Grant discovers new programs each week, validates community submissions opened a
 
 [![Live](https://img.shields.io/badge/live-student--benefits.github.io-blue)](https://student-benefits.github.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
-[![Add Benefit](https://github.com/student-benefits/student-benefits.github.io/actions/workflows/add-benefit.lock.yml/badge.svg)](https://github.com/student-benefits/student-benefits.github.io/actions/workflows/add-benefit.lock.yml)
 
 ---
 


### PR DESCRIPTION
## Summary

The badge in the README pointed at \`add-benefit.lock.yml\`, a gh-aw artifact that no longer exists. The current workflow is \`add-benefit.yml\`. Removing rather than repointing — the live-site and license badges carry the relevant top-of-README signal; a per-workflow CI status badge isn't load-bearing here.