### PR TITLE
Add data-integrity CI gate + harden workflows

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -31,7 +31,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
           allowed_bots: "claude"
-          claude_args: "--model claude-opus-4-8 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You process student benefit submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it, and either open a PR adding the benefit or comment explaining why it can't be added.
 

--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -31,7 +31,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
           allowed_bots: "claude"
-          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-opus-4-8 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You process student benefit submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it, and either open a PR adding the benefit or comment explaining why it can't be added.
 

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -31,7 +31,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
           allowed_bots: "claude"
-          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-opus-4-8 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You process student event submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it against the quality bar, and either open a PR adding the event or comment explaining why it can't be added.
 

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -31,7 +31,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
           allowed_bots: "claude"
-          claude_args: "--model claude-opus-4-8 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You process student event submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it against the quality bar, and either open a PR adding the event or comment explaining why it can't be added.
 

--- a/.github/workflows/discover-benefits.yml
+++ b/.github/workflows/discover-benefits.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You proactively discover student benefits not yet in the directory and open GitHub issues for the best finds. The add-benefit workflow will pick them up.
 

--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You discover student events worth a student's time, remove expired entries, and open one PR with both. Today's date is needed in UTC ISO 8601 — derive it.
 

--- a/.github/workflows/maintain-benefits.yml
+++ b/.github/workflows/maintain-benefits.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-opus-4-8 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You audit every entry in `data/benefits.json` for link health and quality, fix every finding you can, and open a single PR. Findings go directly to a PR — you don't open issues.
 
@@ -53,6 +53,8 @@ jobs:
             ## Step 4: Fix each finding
 
             **Broken/redirected**: WebSearch `"{name}" student discount signup`, WebFetch top result. If valid student page found → update `link`. If program no longer offers a student program → remove the entry. Redirect destinations that are valid → update `link`; otherwise treat as broken.
+
+            Any replacement `link` you choose MUST also pass the Step 3 rule #2 structure check — never a `help.`/`support.`/`docs.`/`blog.` subdomain, a `/articles/` path, or a bare homepage (`/` or `/home`), even if it's the top search result. If the only result is a help/docs article, keep searching for the program's own signup/pricing/overview page. A broken link is no excuse to introduce a forbidden one.
 
             **Quality flags**:
             - **Direct signup link**: WebSearch for the direct student signup page; update `link` if found.

--- a/.github/workflows/maintain-benefits.yml
+++ b/.github/workflows/maintain-benefits.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-opus-4-8 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You audit every entry in `data/benefits.json` for link health and quality, fix every finding you can, and open a single PR. Findings go directly to a PR — you don't open issues.
 

--- a/.github/workflows/scout-reddit.yml
+++ b/.github/workflows/scout-reddit.yml
@@ -36,7 +36,7 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5 --allowedTools 'Edit,Write,Read,WebSearch,WebFetch,Bash(curl:*)'"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,Write,Read,WebSearch,WebFetch,Bash(curl:*)'"
           prompt: |
             You scout Reddit weekly for student-benefit signal. Two modes (controlled by env vars):
             - `MODE=discover` — find new student benefits mentioned in Reddit posts (so the maintainer can add them)

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -1,0 +1,26 @@
+name: Validate Data
+
+on:
+  pull_request:
+    paths:
+      - 'data/benefits.json'
+      - 'data/events.json'
+      - 'data/categories.json'
+      - 'scripts/validate_data.py'
+  push:
+    branches: [main]
+    paths:
+      - 'data/benefits.json'
+      - 'data/events.json'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Validate benefits.json and events.json
+        run: python3 scripts/validate_data.py

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 **/.*
 !.gitignore
 !.gitattributes
+# .github holds CI/workflow config — track it normally (its own contents,
+# not arbitrary dotfiles, are what matter). Without this, new files under
+# .github/ are silently dropped by the rule above.
+!.github/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,10 +115,24 @@ Each workflow is a plain GitHub Actions YAML in `.github/workflows/`. The agent 
 | `discover-benefits.yml` | Weekly (Monday) or manual | Searches for new student benefits, opens issues for the best finds |
 | `discover-events.yml` | Weekly (Wednesday) or manual | Searches for notable student events, removes expired entries, opens one PR |
 | `maintain-benefits.yml` | Weekly (Sunday) or manual | Audits link health and quality, fixes findings, opens one PR |
+| `scout-reddit.yml` | Weekly (Friday) or manual | Scouts Reddit (`site:reddit.com` searches) for benefit mentions (`MODE=discover`) and posting opportunities (`MODE=scout`, → Discord via the `DISCORD_WEBHOOK_URL` secret). State in `agent/state/reddit-state.json`; `DRY_RUN=true` skips writes and the webhook. |
+| `validate-data.yml` | PR touching `data/` or the validator | Runs `scripts/validate_data.py` — the deterministic data-integrity gate. |
 
 Edit a workflow's `prompt:` directly to change Grant's behavior — no compile step.
 
 When adding a new issue template that introduces a new label, create the GitHub label first — templates auto-apply labels, but only if the label already exists in the repo.
+
+No router/orchestrator yet: the two label-triggered workflows (add-benefit, add-event) both fire on any label event and the non-matching one skips correctly. Revisit a dispatcher at 3+ label-triggered workflows.
+
+### Agent state files
+
+Workflows write these; `agent/index.html` reads them to render run history. Never hand-edit — they're regenerated each run.
+
+- `agent/state/last-run.json` — last add-benefit run
+- `agent/state/last-events-submission.json` — last add-event run
+- `agent/state/last-events-discovery.json` — last discover-events run
+- `agent/state/reddit-state.json` — reddit scout state (processed post IDs, subreddit scores, counters)
+- `agent/state/rejected.json` — rejected programs, used for deduplication by add-benefit and scout-reddit
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,14 @@ When adding a new issue template that introduces a new label, create the GitHub 
 
 ## PR review checklist
 
+`scripts/validate_data.py` (run in CI by `validate-data.yml` on any PR touching
+the data files) enforces the structural rules below automatically: schema,
+`id`/`category`/`offer_type` validity, ≤120-char descriptions, canonical
+formatting, and the forbidden-link rule (no `help.`/`support.`/`docs.`/`blog.`
+subdomains, `/articles/` paths, or bare homepages). A red check means the data
+is invalid — don't merge. The remaining items below still need a human eye
+(liveness, duplicates, whether the link is genuinely the signup page).
+
 When reviewing PRs (especially those created by the add-benefit workflow):
 
 - [ ] `id` is unique, URL-safe, matches the name

--- a/agent/index.html
+++ b/agent/index.html
@@ -25,7 +25,7 @@
 
   <section class="identity">
     <h1 class="identity-name">Grant</h1>
-    <p class="identity-role">AI agent · <a href="https://claude.ai" target="_blank" rel="noopener noreferrer">Claude Opus 4.8</a> · Student Benefits Hub</p>
+    <p class="identity-role">AI agent · <a href="https://claude.ai" target="_blank" rel="noopener noreferrer">Claude Sonnet 4.6</a> · Student Benefits Hub</p>
     <p class="identity-desc">
       Grant is an AI agent that curates this directory by verifying submissions, searching the web for new student programs, and opening pull requests. It runs on a schedule to discover and add benefits without waiting for a human to suggest them. A human reviews and merges every PR — Grant handles correctness, the reviewer exercises judgment.
     </p>
@@ -55,7 +55,7 @@
         <div class="arch-node-wrap">
           <button class="arch-node arch-node--grant" id="node-grant" aria-expanded="false" aria-controls="panel-grant">
             <span class="arch-node-label">Grant</span>
-            <span class="arch-node-sublabel">Claude Opus 4.8</span>
+            <span class="arch-node-sublabel">Claude Sonnet 4.6</span>
           </button>
         </div>
 
@@ -114,7 +114,7 @@
           <p>Two issue-triggered workflows process community submissions. <code>add-benefit</code> fires when an issue is labeled <code>new-benefit</code>; <code>add-event</code> fires when an issue is labeled <code>new-event</code>. Both validate the submission, check for duplicates, and open a PR — or comment and close the issue if the submission doesn't pass.</p>
         </div>
         <div id="panel-grant" class="node-panel" hidden>
-          <p class="node-panel-title">Grant · Claude Opus 4.8</p>
+          <p class="node-panel-title">Grant · Claude Sonnet 4.6</p>
           <p>The orchestrator. Grant reads the issue, decides which tools to call, interprets the results, and determines the outcome without human approval of intermediate steps. Its output depends on the workflow and the outcome — a PR, a comment, a closed issue, or a combination. Its instructions are a Markdown file checked into this repository.</p>
         </div>
         <div id="panel-tavily" class="node-panel" hidden>

--- a/agent/index.html
+++ b/agent/index.html
@@ -25,7 +25,7 @@
 
   <section class="identity">
     <h1 class="identity-name">Grant</h1>
-    <p class="identity-role">AI agent · <a href="https://claude.ai" target="_blank" rel="noopener noreferrer">Claude Sonnet 4.5</a> · Student Benefits Hub</p>
+    <p class="identity-role">AI agent · <a href="https://claude.ai" target="_blank" rel="noopener noreferrer">Claude Opus 4.8</a> · Student Benefits Hub</p>
     <p class="identity-desc">
       Grant is an AI agent that curates this directory by verifying submissions, searching the web for new student programs, and opening pull requests. It runs on a schedule to discover and add benefits without waiting for a human to suggest them. A human reviews and merges every PR — Grant handles correctness, the reviewer exercises judgment.
     </p>
@@ -55,7 +55,7 @@
         <div class="arch-node-wrap">
           <button class="arch-node arch-node--grant" id="node-grant" aria-expanded="false" aria-controls="panel-grant">
             <span class="arch-node-label">Grant</span>
-            <span class="arch-node-sublabel">Claude Sonnet 4.5</span>
+            <span class="arch-node-sublabel">Claude Opus 4.8</span>
           </button>
         </div>
 
@@ -114,7 +114,7 @@
           <p>Two issue-triggered workflows process community submissions. <code>add-benefit</code> fires when an issue is labeled <code>new-benefit</code>; <code>add-event</code> fires when an issue is labeled <code>new-event</code>. Both validate the submission, check for duplicates, and open a PR — or comment and close the issue if the submission doesn't pass.</p>
         </div>
         <div id="panel-grant" class="node-panel" hidden>
-          <p class="node-panel-title">Grant · Claude Sonnet 4.5</p>
+          <p class="node-panel-title">Grant · Claude Opus 4.8</p>
           <p>The orchestrator. Grant reads the issue, decides which tools to call, interprets the results, and determines the outcome without human approval of intermediate steps. Its output depends on the workflow and the outcome — a PR, a comment, a closed issue, or a combination. Its instructions are a Markdown file checked into this repository.</p>
         </div>
         <div id="panel-tavily" class="node-panel" hidden>

--- a/data/benefits.json
+++ b/data/benefits.json
@@ -303,7 +303,7 @@
     "category": "Lifestyle",
     "offer_type": "discount",
     "description": "Free access to hundreds of verified student discounts on fashion, tech, food, travel, and entertainment.",
-    "link": "https://www.myunidays.com/",
+    "link": "https://www.myunidays.com/US/en-US/account/register",
     "tags": [
       "Discounts",
       "Shopping"
@@ -428,7 +428,7 @@
     "category": "Productivity",
     "offer_type": "discount",
     "description": "50-75% off Loom for verified students and educators. Unlimited recordings, HD quality, and full editing tools.",
-    "link": "https://support.atlassian.com/loom/docs/education-plan-faq/",
+    "link": "https://www.loom.com/use-case/education",
     "tags": [
       "Video",
       "Recording",
@@ -456,7 +456,7 @@
     "category": "Learning",
     "offer_type": "free",
     "description": "Free 1000+ courses in AI, cybersecurity, cloud, and data science. Earn industry-recognized credentials.",
-    "link": "https://skillsbuild.org/",
+    "link": "https://skillsbuild.org/students",
     "tags": [
       "Courses",
       "Certifications",
@@ -511,7 +511,7 @@
     "category": "Productivity",
     "offer_type": "free",
     "description": "Free Team plan for 6-24 months. Instant 120-day trial with .edu email, then apply for extended access.",
-    "link": "https://support.airtable.com/docs/nonprofit-and-educational-plans-faqs",
+    "link": "https://www.airtable.com/solutions/education",
     "tags": [
       "Database",
       "No-Code",
@@ -525,7 +525,7 @@
     "category": "Learning",
     "offer_type": "discount",
     "description": "10-20% off student subscription for cybersecurity training. Hands-on labs, challenges, and career-focused content.",
-    "link": "https://help.hackthebox.com/en/articles/13465244-getting-the-student-subscription",
+    "link": "https://academy.hackthebox.com/login",
     "tags": [
       "Cybersecurity",
       "Hacking",
@@ -637,7 +637,7 @@
     "category": "Cloud & Hosting",
     "offer_type": "free",
     "description": "Free RHEL subscription for up to 16 systems. Full access to updates and self-service support. Renewable annually.",
-    "link": "https://developers.redhat.com/",
+    "link": "https://developers.redhat.com/register",
     "tags": [
       "Linux",
       "Enterprise",

--- a/data/events.json
+++ b/data/events.json
@@ -39,20 +39,6 @@
     "expires": "2027-04-04"
   },
   {
-    "id": "google-io-2026",
-    "name": "Google I/O 2026",
-    "organizer": "Google",
-    "category": "conference",
-    "date": "2026-05-19",
-    "date_end": "2026-05-20",
-    "location": "Mountain View, CA",
-    "remote": false,
-    "eligibility": "Open to all; online attendance is free",
-    "why": "Google's flagship developer conference \u2014 free online stream. New APIs and SDKs are announced here first, before documentation catches up.",
-    "link": "https://io.google/2026/",
-    "expires": "2026-05-20"
-  },
-  {
     "id": "iim-ahmedabad-ai-residency-2026",
     "name": "IIM Ahmedabad AI Summer Residency 2026",
     "organizer": "IIM Ahmedabad Ventures",
@@ -65,6 +51,20 @@
     "why": "Free 4-6 week residency with housing, cloud credits, and mentorship to build production-ready AI products. Move beyond hackathon demos to real-world applications.",
     "link": "https://gp12pzj7qtu.typeform.com/ai-residency",
     "expires": "2026-06-30"
+  },
+  {
+    "id": "google-io-2026",
+    "name": "Google I/O 2026",
+    "organizer": "Google",
+    "category": "conference",
+    "date": "2026-05-19",
+    "date_end": "2026-05-20",
+    "location": "Mountain View, CA",
+    "remote": false,
+    "eligibility": "Open to all; online attendance is free",
+    "why": "Google's flagship developer conference — free online stream. New APIs and SDKs are announced here first, before documentation catches up.",
+    "link": "https://io.google/2026/",
+    "expires": "2026-05-20"
   },
   {
     "id": "quackhacks-3-2026",
@@ -144,7 +144,7 @@
     "location": "San Francisco, CA",
     "remote": false,
     "eligibility": "Undergraduate CS or engineering students worldwide; no company required",
-    "why": "$20k cash + $90k in compute credits to build a self-directed AI project in SF. YC picks 20\u201350 students; no company or team required.",
+    "why": "$20k cash + $90k in compute credits to build a self-directed AI project in SF. YC picks 20–50 students; no company or team required.",
     "link": "https://events.ycombinator.com/summer-grants-26",
     "expires": "2026-08-22"
   },
@@ -158,7 +158,7 @@
     "location": "San Francisco, CA",
     "remote": false,
     "eligibility": "CS undergrads, masters, and PhD students",
-    "why": "Free, in-person, highly selective. Speakers include Sam Altman, Andrej Karpathy, and Andrew Ng \u2014 for CS students who want to build AI companies, this is the room.",
+    "why": "Free, in-person, highly selective. Speakers include Sam Altman, Andrej Karpathy, and Andrew Ng — for CS students who want to build AI companies, this is the room.",
     "link": "https://www.ycombinator.com/blog/ai-startupschool",
     "expires": "2026-06-17"
   },
@@ -212,7 +212,7 @@
     "date_end": "2026-11-30",
     "remote": true,
     "eligibility": "Undergrads through professionals worldwide; DC track requires US work authorization",
-    "why": "$15\u201322k stipend, two-week DC residency, direct mentorship from leading AI governance experts. Past fellows joined CSET, GovAI, and major tech policy shops.",
+    "why": "$15–22k stipend, two-week DC residency, direct mentorship from leading AI governance experts. Past fellows joined CSET, GovAI, and major tech policy shops.",
     "link": "https://www.iaps.ai/fellowship",
     "expires": "2026-11-30"
   },

--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -22,7 +22,6 @@ DATA = ROOT / "data"
 ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 OFFER_TYPES = {"free", "discount", "credits", "trial"}
-EVENT_CATEGORIES = {"hackathon", "conference", "fellowship", "summit", "workshop", "grant"}
 # subdomains/paths that are documentation, not signup destinations (see PR #197)
 FORBIDDEN_SUBDOMAINS = ("help.", "support.", "docs.", "blog.")
 FORBIDDEN_PATH = "/articles/"
@@ -102,6 +101,7 @@ def validate_events() -> None:
     if not isinstance(data, list):
         err("events.json: top-level must be a list")
         return
+    categories = set(json.loads((DATA / "event-categories.json").read_text(encoding="utf-8")))
     seen_ids: set[str] = set()
     dates: list[str] = []
     for i, e in enumerate(data):
@@ -116,8 +116,8 @@ def validate_events() -> None:
             if eid in seen_ids:
                 err(f"{name}: duplicate id '{eid}'")
             seen_ids.add(eid)
-        if e.get("category") not in EVENT_CATEGORIES:
-            err(f"{name}: category '{e.get('category')}' not one of {sorted(EVENT_CATEGORIES)}")
+        if e.get("category") not in categories:
+            err(f"{name}: category '{e.get('category')}' not in event-categories.json")
         if len(e.get("why", "")) > 200:
             err(f"{name}: why is {len(e.get('why',''))} chars (max 200)")
         for dk in ("date", "date_end", "expires"):

--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Validate data/benefits.json and data/events.json against the schema.
+
+Deterministic gate for the data integrity rules in CLAUDE.md. Runs in CI on
+every PR that touches the data files, so the rules hold regardless of which
+workflow (or which model) produced the change.
+
+Checks structure and URL shape only — never fetches links. Liveness is the
+maintain-benefits workflow's job; this gate is about what we can prove offline.
+
+Exit 0 if clean, 1 if any error.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parent.parent
+DATA = ROOT / "data"
+
+ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+OFFER_TYPES = {"free", "discount", "credits", "trial"}
+EVENT_CATEGORIES = {"hackathon", "conference", "fellowship", "summit", "workshop", "grant"}
+# subdomains/paths that are documentation, not signup destinations (see PR #197)
+FORBIDDEN_SUBDOMAINS = ("help.", "support.", "docs.", "blog.")
+FORBIDDEN_PATH = "/articles/"
+
+errors: list[str] = []
+
+
+def err(msg: str) -> None:
+    errors.append(msg)
+
+
+def load(name: str):
+    path = DATA / name
+    raw = path.read_text(encoding="utf-8")
+    data = json.loads(raw)
+    # canonical formatting: 2-space indent, unicode preserved, trailing newline
+    canonical = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    if raw != canonical:
+        err(f"{name}: not canonically formatted (expected 2-space indent + trailing newline)")
+    return data
+
+
+def check_link(name: str, link: str) -> None:
+    parsed = urlparse(link)
+    if parsed.scheme != "https":
+        err(f"{name}: link must be https — {link}")
+        return
+    host = parsed.netloc.lower()
+    path = parsed.path or "/"
+    if host.startswith(FORBIDDEN_SUBDOMAINS):
+        err(f"{name}: link uses a documentation subdomain (help/support/docs/blog) — {link}")
+    if FORBIDDEN_PATH in path:
+        err(f"{name}: link is a help/docs article (/articles/) — {link}")
+    if path in ("/", "/home"):
+        err(f"{name}: link points at the homepage, not a signup/program page — {link}")
+
+
+def validate_benefits() -> None:
+    data = load("benefits.json")
+    if not isinstance(data, list):
+        err("benefits.json: top-level must be a list")
+        return
+    categories = set(json.loads((DATA / "categories.json").read_text(encoding="utf-8")))
+    seen_ids: set[str] = set()
+    for i, b in enumerate(data):
+        tag = f"benefits[{i}]"
+        name = b.get("name", tag)
+        for key in ("id", "name", "category", "offer_type", "description", "link", "tags", "popularity"):
+            if key not in b:
+                err(f"{name}: missing required field '{key}'")
+        bid = b.get("id", "")
+        if bid:
+            if not ID_RE.match(bid):
+                err(f"{name}: id '{bid}' must be lowercase, hyphen-separated, no leading/trailing hyphen")
+            if bid in seen_ids:
+                err(f"{name}: duplicate id '{bid}'")
+            seen_ids.add(bid)
+        if b.get("category") not in categories:
+            err(f"{name}: category '{b.get('category')}' not in categories.json")
+        if b.get("offer_type") not in OFFER_TYPES:
+            err(f"{name}: offer_type '{b.get('offer_type')}' not one of {sorted(OFFER_TYPES)}")
+        desc = b.get("description", "")
+        if len(desc) > 120:
+            err(f"{name}: description is {len(desc)} chars (max 120)")
+        pop = b.get("popularity")
+        if not isinstance(pop, int) or not (1 <= pop <= 10):
+            err(f"{name}: popularity must be an integer 1-10, got {pop!r}")
+        tags = b.get("tags")
+        if not isinstance(tags, list) or not tags:
+            err(f"{name}: tags must be a non-empty list")
+        if isinstance(b.get("link"), str):
+            check_link(name, b["link"])
+
+
+def validate_events() -> None:
+    data = load("events.json")
+    if not isinstance(data, list):
+        err("events.json: top-level must be a list")
+        return
+    seen_ids: set[str] = set()
+    dates: list[str] = []
+    for i, e in enumerate(data):
+        name = e.get("name", f"events[{i}]")
+        for key in ("id", "name", "organizer", "category", "date", "remote", "eligibility", "why", "link", "expires"):
+            if key not in e:
+                err(f"{name}: missing required field '{key}'")
+        eid = e.get("id", "")
+        if eid:
+            if not ID_RE.match(eid):
+                err(f"{name}: id '{eid}' must be lowercase, hyphen-separated")
+            if eid in seen_ids:
+                err(f"{name}: duplicate id '{eid}'")
+            seen_ids.add(eid)
+        if e.get("category") not in EVENT_CATEGORIES:
+            err(f"{name}: category '{e.get('category')}' not one of {sorted(EVENT_CATEGORIES)}")
+        if len(e.get("why", "")) > 200:
+            err(f"{name}: why is {len(e.get('why',''))} chars (max 200)")
+        for dk in ("date", "date_end", "expires"):
+            if dk in e and not DATE_RE.match(str(e[dk])):
+                err(f"{name}: {dk} '{e[dk]}' must be YYYY-MM-DD")
+        if isinstance(e.get("date"), str) and DATE_RE.match(e["date"]):
+            dates.append(e["date"])
+    if dates != sorted(dates):
+        err("events.json: entries must be sorted by date (earliest first)")
+
+
+def main() -> int:
+    validate_benefits()
+    validate_events()
+    if errors:
+        print(f"✗ {len(errors)} validation error(s):", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+    print("✓ data/benefits.json and data/events.json are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR #197 forbade help-article links, but the rule was prompt-only — and a maintain run (#201) reintroduced the *exact* forbidden TryHackMe/Jitter links **3 days after** the fix merged. Prompt rules don't hold. This makes the rule a deterministic gate and closes the loophole that let it slip.

### What changed

**1. Data-integrity gate**
- `scripts/validate_data.py` + `.github/workflows/validate-data.yml` — validates `benefits.json` and `events.json` on every PR that touches them. Enforces, structurally (independent of any model):
  - schema completeness, `id` format + uniqueness, `category` ∈ categories.json, `offer_type` enum, `popularity` 1–10
  - description ≤ 120 chars
  - canonical formatting (2-space indent, trailing newline)
  - event sort order + `why` ≤ 200
  - **forbidden-link rule**: no `help.`/`support.`/`docs.`/`blog.` subdomains, no `/articles/` paths, no bare homepages

**2. Closed the #201 loophole**
- maintain-benefits **Step 4** now requires any *replacement* link to pass the same structure check as existing links. The ban previously lived only in Step 3 (judging existing links), so a broken-link fix could freely pick a help article — exactly what happened.

**3. Model refresh off EOL `claude-sonnet-4-5`**
- All six workflows → `claude-sonnet-4-6` (current Sonnet). Agent page label synced.

**4. Debt the new gate surfaced (cleaned so CI is green)**
- 6 benefit links violating the help/homepage rule repointed to real signup pages: UNiDAYS, Loom, IBM SkillsBuild, Airtable, Hack The Box, Red Hat.
- `events.json` sorted by date (main was unsorted, against the CLAUDE.md rule) and normalized to match `benefits.json` encoding.

Validator passes clean locally. All workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)