### PR TITLE
Add Datadog, Codecov, Sentry, and Bootstrap Studio

### DIFF
--- a/agent/state/last-run.json
+++ b/agent/state/last-run.json
@@ -1,25 +1,25 @@
 {
-  "issue": 125,
-  "title": "[benefit]: lumix education",
-  "timestamp": "2026-05-21T00:00:00Z",
+  "issue": 205,
+  "title": "datadog",
+  "timestamp": "2026-05-25T00:00:00Z",
   "outcome": "accepted",
   "tools": [
     {
       "name": "websearch",
-      "query": "Lumix education program student discount"
+      "query": "Datadog student program GitHub Student Developer Pack"
     },
     {
       "name": "webfetch",
-      "url": "https://shop.panasonic.com/pages/lumix-education-program"
+      "url": "https://www.datadoghq.com/blog/datadog-github-student-developer-pack/"
     },
     {
       "name": "edit",
-      "summary": "Added LUMIX EDU entry to benefits.json"
+      "summary": "Added Datadog entry to data/benefits.json"
     }
   ],
   "benefit": {
-    "name": "LUMIX EDU",
-    "category": "Design",
-    "description": "15% off cameras and lenses, plus free curriculum resources, equipment borrowing, and training workshops."
+    "name": "Datadog",
+    "category": "Dev Tools",
+    "description": "Free Pro for 2 years. Monitor 10 hosts, 500 GB logs, 1,000 browser tests, 15-month data retention."
   }
 }

--- a/data/benefits.json
+++ b/data/benefits.json
@@ -930,5 +930,62 @@
       "Motion Design"
     ],
     "popularity": 5
+  },
+  {
+    "id": "datadog",
+    "name": "Datadog",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free Pro for 2 years. Monitor 10 hosts, 500 GB logs, 1,000 browser tests, 15-month data retention.",
+    "link": "https://studentpack.datadoghq.com/signup",
+    "tags": [
+      "Monitoring",
+      "Observability",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "codecov",
+    "name": "Codecov",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free code coverage forever on public and private repositories. Included in GitHub Student Pack.",
+    "link": "https://about.codecov.io/solution/students",
+    "tags": [
+      "Code Coverage",
+      "Testing",
+      "CI/CD",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "sentry",
+    "name": "Sentry",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free 1-year education plan with 50K errors/month, unlimited team members, and AI debugging.",
+    "link": "https://sentry.io/for/education",
+    "tags": [
+      "Error Tracking",
+      "Monitoring",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "bootstrap-studio",
+    "name": "Bootstrap Studio",
+    "category": "Design",
+    "offer_type": "free",
+    "description": "Free desktop app license for building responsive Bootstrap websites while enrolled.",
+    "link": "https://bootstrapstudio.io/students",
+    "tags": [
+      "Web Design",
+      "Bootstrap",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
   }
 ]


### PR DESCRIPTION
## Summary

Consolidates four new-benefit submissions (#205, #203, #202, #206) into one PR. Each originally appended to the end of `data/benefits.json` and rewrote `last-run.json`, so they conflicted pairwise — merging them separately meant a manual conflict on every one after the first. This is one clean, gate-green merge.

All four are part of the GitHub Student Pack. Links were verified against the new data-integrity gate from #212:

| Benefit | Category | Link |
|---|---|---|
| Datadog | Dev Tools | `studentpack.datadoghq.com/signup` (was bare homepage — fixed) |
| Codecov | Dev Tools | `about.codecov.io/solution/students` |
| Sentry | Dev Tools | `sentry.io/for/education` |
| Bootstrap Studio | Design | `bootstrapstudio.io/students` (was `/contact-us` — fixed) |

Supersedes PRs #207, #208, #209, #210 (will close those as superseded).

Closes #205
Closes #203
Closes #202
Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)