### PR TITLE
Add PR Concierge: daily ready-for-review sweep

### DIFF
--- a/.github/workflows/pr-concierge.yml
+++ b/.github/workflows/pr-concierge.yml
@@ -1,0 +1,110 @@
+name: PR Concierge
+
+# Once-daily sweep of open PRs. When a PR has crossed "ready" — required checks
+# green AND any bot review (e.g. Copilot) is in — it posts a single @-mention
+# comment so the maintainer can make the merge call, then labels the PR
+# `ready-for-review` so it is never pinged twice. Deterministic: no LLM, no token
+# cost. The merge itself stays a human decision (the trust boundary).
+
+on:
+  schedule:
+    # 13:00 UTC daily — batches overnight bot-PR bursts into one review session.
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (classify and log, but post no comments or labels)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  concierge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write   # post comments, add the label to a PR
+      issues: write          # gh label create (labels are the issues API)
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+    steps:
+      - name: Ensure ready-for-review label exists
+        if: env.DRY_RUN != 'true'
+        run: |
+          gh label create ready-for-review \
+            --repo "$GITHUB_REPOSITORY" \
+            --color 0E8A16 \
+            --description "CI green + bot-reviewed; awaiting maintainer merge" \
+            --force
+
+      - name: Sweep open PRs and flag the ready ones
+        run: |
+          set -euo pipefail
+
+          # A PR is "ready" when, ignoring drafts / the maintainer's own PRs /
+          # already-flagged PRs, every check is positively green. The rollup is a
+          # union: GitHub Actions emit CheckRun (.status + .conclusion); legacy
+          # commit-status integrations emit StatusContext (.state only) — both are
+          # handled. An empty rollup (PRs touching no checked paths) is CI-clear,
+          # not a block. Copilot's verdict is surfaced for context but never gates
+          # the ping (it sometimes errors), so a green PR is never stuck on it.
+          ready=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --json number,title,isDraft,author,labels,statusCheckRollup,reviews \
+            | jq -c '
+              def copilot:
+                ([.reviews[]? | select(.author.login=="copilot-pull-request-reviewer")] | last);
+              def bad:   (.conclusion // .state) as $x
+                | ($x=="FAILURE" or $x=="CANCELLED" or $x=="TIMED_OUT"
+                   or $x=="ACTION_REQUIRED" or $x=="STARTUP_FAILURE" or $x=="ERROR");
+              def green: (.status=="COMPLETED"
+                          and (.conclusion=="SUCCESS" or .conclusion=="NEUTRAL"
+                               or .conclusion=="SKIPPED"))
+                         or (.state=="SUCCESS");
+              def ci:
+                (.statusCheckRollup // []) as $c
+                | if   ($c | any(bad))         then "failed"
+                  elif ($c | any(green | not)) then "pending"
+                  else "ok" end;
+              .[]
+              | select(.isDraft | not)
+              | select(.author.login != "jonasneves")
+              | select([.labels[]?.name] | index("ready-for-review") | not)
+              | { number, title, ci: ci,
+                  cilabel: (if ((.statusCheckRollup // []) | length) == 0
+                            then "no CI checks" else "checks ✓" end),
+                  copilot: ( copilot as $r
+                    | if   $r == null then "not reviewed yet"
+                      elif ($r.body | test("encountered an error")) then "errored — review manually"
+                      elif ($r.body | test("generated [0-9]+ comment"))
+                        then ($r.body | capture("generated (?<n>[0-9]+) comment").n + " comment(s)")
+                      else "reviewed" end ) }
+              | select(.ci == "ok")
+            ')
+
+          if [ -z "$ready" ]; then
+            echo "Nothing newly ready. No comments posted."
+            exit 0
+          fi
+
+          echo "$ready" | while IFS= read -r pr; do
+            num=$(echo "$pr"     | jq -r .number)
+            cilabel=$(echo "$pr" | jq -r .cilabel)
+            copilot=$(echo "$pr" | jq -r .copilot)
+            body=$(printf '@jonasneves Ready for review — %s · Copilot: %s\n\n<sub>Auto-flagged by PR Concierge: required checks are green. The merge call is yours.</sub>' "$cilabel" "$copilot")
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] would flag #$num (CI: $cilabel; Copilot: $copilot)"
+              continue
+            fi
+
+            # Label first: it is the dedup token. If it lands but the comment fails,
+            # the PR is silently skipped next run (recoverable) rather than re-pinged.
+            # Each write is non-fatal so one bad PR doesn't abort the rest of the sweep.
+            gh pr edit "$num" --repo "$GITHUB_REPOSITORY" --add-label ready-for-review \
+              || { echo "warn: could not label #$num — skipping"; continue; }
+            gh pr comment "$num" --repo "$GITHUB_REPOSITORY" --body "$body" \
+              || { echo "warn: labeled #$num but comment failed"; continue; }
+            echo "flagged #$num (CI: $cilabel; Copilot: $copilot)"
+          done

--- a/.github/workflows/pr-concierge.yml
+++ b/.github/workflows/pr-concierge.yml
@@ -1,10 +1,11 @@
 name: PR Concierge
 
-# Once-daily sweep of open PRs. When a PR has crossed "ready" — required checks
-# green AND any bot review (e.g. Copilot) is in — it posts a single @-mention
-# comment so the maintainer can make the merge call, then labels the PR
-# `ready-for-review` so it is never pinged twice. Deterministic: no LLM, no token
-# cost. The merge itself stays a human decision (the trust boundary).
+# Once-daily sweep of open PRs. When a PR's required checks are green it posts a
+# single @-mention comment so the maintainer can make the merge call, then labels
+# the PR `ready-for-review` so it is never pinged twice. Any bot review (e.g.
+# Copilot) is surfaced in the comment for context but does NOT gate the ping —
+# CI is the only gate. Deterministic: no LLM, no token cost. The merge itself
+# stays a human decision (the trust boundary).
 
 on:
   schedule:
@@ -36,7 +37,7 @@ jobs:
           gh label create ready-for-review \
             --repo "$GITHUB_REPOSITORY" \
             --color 0E8A16 \
-            --description "CI green + bot-reviewed; awaiting maintainer merge" \
+            --description "CI green; flagged by PR Concierge, awaiting maintainer merge" \
             --force
 
       - name: Sweep open PRs and flag the ready ones
@@ -50,7 +51,7 @@ jobs:
           # handled. An empty rollup (PRs touching no checked paths) is CI-clear,
           # not a block. Copilot's verdict is surfaced for context but never gates
           # the ping (it sometimes errors), so a green PR is never stuck on it.
-          ready=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+          ready=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 200 \
             --json number,title,isDraft,author,labels,statusCheckRollup,reviews \
             | jq -c '
               def copilot:
@@ -75,10 +76,11 @@ jobs:
                   cilabel: (if ((.statusCheckRollup // []) | length) == 0
                             then "no CI checks" else "checks ✓" end),
                   copilot: ( copilot as $r
+                    | ($r.body // "") as $b   # body can be null; coercing avoids a test() throw
                     | if   $r == null then "not reviewed yet"
-                      elif ($r.body | test("encountered an error")) then "errored — review manually"
-                      elif ($r.body | test("generated [0-9]+ comment"))
-                        then ($r.body | capture("generated (?<n>[0-9]+) comment").n + " comment(s)")
+                      elif ($b | test("encountered an error")) then "errored — review manually"
+                      elif ($b | test("generated [0-9]+ comment"))
+                        then ($b | capture("generated (?<n>[0-9]+) comment").n + " comment(s)")
                       else "reviewed" end ) }
               | select(.ci == "ok")
             ')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ Each workflow is a plain GitHub Actions YAML in `.github/workflows/`. The agent 
 | `maintain-benefits.yml` | Weekly (Sunday) or manual | Audits link health and quality, fixes findings, opens one PR |
 | `scout-reddit.yml` | Weekly (Friday) or manual | Scouts Reddit (`site:reddit.com` searches) for benefit mentions (`MODE=discover`) and posting opportunities (`MODE=scout`, → Discord via the `DISCORD_WEBHOOK_URL` secret). State in `agent/state/reddit-state.json`; `DRY_RUN=true` skips writes and the webhook. |
 | `validate-data.yml` | PR touching `data/` or the validator | Runs `scripts/validate_data.py` — the deterministic data-integrity gate. |
+| `pr-concierge.yml` | Daily (13:00 UTC) or manual | Sweeps open PRs; once a PR's checks are green and any bot review is in, posts one `@jonasneves` comment and labels it `ready-for-review` (idempotent dedup marker). Surfaces Copilot's verdict; never gates on it, never merges. Deterministic — no LLM. |
 
 Edit a workflow's `prompt:` directly to change Grant's behavior — no compile step.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Each workflow is a plain GitHub Actions YAML in `.github/workflows/`. The agent 
 | `maintain-benefits.yml` | Weekly (Sunday) or manual | Audits link health and quality, fixes findings, opens one PR |
 | `scout-reddit.yml` | Weekly (Friday) or manual | Scouts Reddit (`site:reddit.com` searches) for benefit mentions (`MODE=discover`) and posting opportunities (`MODE=scout`, → Discord via the `DISCORD_WEBHOOK_URL` secret). State in `agent/state/reddit-state.json`; `DRY_RUN=true` skips writes and the webhook. |
 | `validate-data.yml` | PR touching `data/` or the validator | Runs `scripts/validate_data.py` — the deterministic data-integrity gate. |
-| `pr-concierge.yml` | Daily (13:00 UTC) or manual | Sweeps open PRs; once a PR's checks are green and any bot review is in, posts one `@jonasneves` comment and labels it `ready-for-review` (idempotent dedup marker). Surfaces Copilot's verdict; never gates on it, never merges. Deterministic — no LLM. |
+| `pr-concierge.yml` | Daily (13:00 UTC) or manual | Sweeps open PRs; once a PR's required checks are green, posts one `@jonasneves` comment and labels it `ready-for-review` (idempotent dedup marker). Surfaces Copilot's verdict in the comment but gates only on CI; never merges. Deterministic — no LLM. |
 
 Edit a workflow's `prompt:` directly to change Grant's behavior — no compile step.
 


### PR DESCRIPTION
## Summary

Adds `pr-concierge.yml` — a once-daily, **deterministic** (no-LLM, zero-token) sweep of open PRs. When a PR has crossed *ready* — required checks green **and** any bot review (Copilot) is in — it posts a single `@jonasneves` comment and labels the PR `ready-for-review`. That collapses "go look at every open PR" into "here are the ones worth your merge decision."

Answers the ask: *watch new PRs, surface bot reviews, ping me only when really ready*. Chosen over a local `/loop` (session-bound, can't notify when you're away) and over per-event triggers (Grant opens PRs in bursts → notification spam). A daily batch matches how the PRs actually arrive.

## Behavior
- **Hard gate:** required checks green. Handles the full `statusCheckRollup` union (Actions `CheckRun` + legacy `StatusContext`); an empty rollup (PRs touching no checked paths) is CI-clear, not a block. Checks `failed` → skipped; `pending` → waits for tomorrow.
- **Soft signal:** Copilot's verdict (clean / N comments / errored / not-reviewed) is surfaced in the comment but **never gates** the ping — so a green PR is never stuck behind a flaky bot.
- **Idempotent:** the `ready-for-review` label is the dedup token, written *before* the comment and non-fatally, so a partial failure leaves a PR silently skipped (recoverable), never re-pinged. One bad PR doesn't abort the rest of the sweep.
- **Never merges.** The merge stays the human trust boundary.
- Drafts and your own PRs are skipped. `workflow_dispatch` supports `dry_run`.

## Precondition (separate, one-time)
Copilot auto-review is currently **off** (new PRs request only you). Until it's enabled in repo settings, the comment will honestly read `Copilot: not reviewed yet`. The workflow degrades gracefully either way.

## Validation
- YAML parses; jq classifier dry-run against live open PRs correctly flags every green PR and excludes the one with a failed `validate` check.
- Audited (`audit` agent); all HIGH findings (non-atomic dedup, `set -e` sweep-abort, `StatusContext` blind spot) fixed before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)