### PR TITLE
lens-audit: agent page describes the real system; add cron falsifiability

### DIFF
--- a/.github/workflows/discover-benefits.yml
+++ b/.github/workflows/discover-benefits.yml
@@ -1,5 +1,13 @@
 name: Discover Student Benefits
 
+# Falsifiability (per the "running systems" convention — criterion is contract, cycle history is the Actions run log).
+#   Working-when: each scheduled run COMPLETES and leaves a positive trace of having looked — either ≥1 `new-benefit`
+#     issue opened, OR `agent/state/last-benefits-discovery.json` rewritten with a fresh `timestamp` (the dated "searched,
+#     nothing met the bar" heartbeat). NOT a found-count: silence-by-design (a dry week) is healthy iff the heartbeat moves.
+#     A run that opens nothing AND doesn't bump the timestamp = the cron silently isn't firing/committing → broken, not empty.
+#   Teardown after N: 8 weekly cycles (~2 months). If working-when is unmet for 8 consecutive Mondays (timestamp never
+#     advances / Actions shows no scheduled runs), the discovery thesis is wrong → remove this workflow. (N is Jonas's to tune.)
+
 on:
   schedule:
     - cron: '0 14 * * 1'  # Monday 14:00 UTC

--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -1,5 +1,14 @@
 name: Discover Student Events
 
+# Falsifiability (per the "running systems" convention — criterion is contract, cycle history is the Actions run log).
+#   Working-when: each scheduled run COMPLETES and leaves a positive trace — either a PR opened (new events and/or expired
+#     removals), OR `agent/state/last-events-discovery.json` rewritten with a fresh `timestamp` (the dated "searched + checked
+#     expiries, nothing actionable" heartbeat). NOT a found-count. A run that bumps the timestamp but never PRs is healthy;
+#     a timestamp that never advances = the cron silently isn't firing → broken, not empty. (Stale events not auto-expiring
+#     is the observable symptom of this being broken.)
+#   Teardown after N: 8 weekly cycles (~2 months). If working-when is unmet for 8 consecutive Wednesdays, the thesis is
+#     wrong → remove this workflow. (N is Jonas's to tune.)
+
 on:
   schedule:
     - cron: '0 14 * * 3'  # Wednesday 14:00 UTC

--- a/.github/workflows/maintain-benefits.yml
+++ b/.github/workflows/maintain-benefits.yml
@@ -1,5 +1,14 @@
 name: Maintain Benefits
 
+# Falsifiability (per the "running systems" convention — criterion is contract, cycle history is the Actions run log).
+#   Working-when: each scheduled run COMPLETES the audit — observable as either a `[Maintenance]` PR opened, OR (when no
+#     fixes were needed) an outcome comment closing every open `link-health` issue ("All benefits are healthy." / "{N}
+#     require manual review"). NOT a fixed-count: a clean audit (no fixes, no open link-health issues) is healthy, but that
+#     case leaves no artifact, so liveness here is verified primarily from the Actions run log showing the scheduled run ran
+#     green. A Sunday with NO run in the Actions log = the cron silently isn't firing → broken, not empty.
+#   Teardown after N: 8 weekly cycles (~2 months). If no scheduled run appears for 8 consecutive Sundays, the
+#     auto-maintenance thesis is wrong → remove this workflow. (N is Jonas's to tune.)
+
 on:
   schedule:
     - cron: '0 14 * * 0'  # Sunday 14:00 UTC

--- a/.github/workflows/scout-reddit.yml
+++ b/.github/workflows/scout-reddit.yml
@@ -1,5 +1,14 @@
 name: Scout Reddit
 
+# Falsifiability (per the "running systems" convention — criterion is contract, cycle history is the Actions run log).
+#   Working-when: each scheduled (non-dry-run) run rewrites `agent/state/reddit-state.json` with a fresh `last_run`
+#     timestamp and pushes it (the "Commit state changes" step) — the always-present dated heartbeat. NOT a
+#     discoveries/opportunities count: a quiet week (no new posts, nothing sent to Discord) is healthy iff `last_run`
+#     still advances. A `last_run` that doesn't move week-over-week = the cron silently isn't firing/committing → broken,
+#     not empty. (As of this writing `last_run` is months stale — exactly the silent-cron failure to verify.)
+#   Teardown after N: 8 weekly cycles (~2 months). If `last_run` never advances across 8 consecutive Fridays, the
+#     Reddit-signal thesis is wrong → remove this workflow. (N is Jonas's to tune.)
+
 on:
   schedule:
     # Friday 14:00 UTC — catches posts from the week, leaves weekend to act

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,19 @@ When adding a new issue template that introduces a new label, create the GitHub 
 
 No router/orchestrator yet: the two label-triggered workflows (add-benefit, add-event) both fire on any label event and the non-matching one skips correctly. Revisit a dispatcher at 3+ label-triggered workflows.
 
+### Falsifiability (scheduled workflows)
+
+Every cron workflow carries, in its YAML, a **working-when** criterion + an **N-cycle teardown** clause (the "running systems" convention). **Criteria are contract** (in the files); **cycle history is state** (the Actions run log) — don't restate run history here. The criteria are silence-tolerant by design: these are discovery/maintenance surfacers that *may legitimately find nothing* some weeks, so the test is **the pipeline being alive**, never an output count. Working-when = a scheduled run *completes and leaves a positive trace of having looked* (an issue/PR, or a dated heartbeat in its state file). Default N = **8 weekly cycles (~2 months)** for each; Jonas's to tune.
+
+| Workflow | Working-when (positive trace) | N |
+|---|---|---|
+| `discover-benefits` | `new-benefit` issue opened **or** `last-benefits-discovery.json` timestamp bumped | 8 wk |
+| `discover-events` | PR opened **or** `last-events-discovery.json` timestamp bumped | 8 wk |
+| `maintain-benefits` | `[Maintenance]` PR **or** `link-health` issues closed with outcome; else green scheduled run in Actions log | 8 wk |
+| `scout-reddit` | `reddit-state.json` `last_run` advances (committed by the push step) | 8 wk |
+
+**The criterion's FIRST job is catching a cron that silently isn't running** — not weak output. This is live: `agent/state/last-benefits-discovery.json` is **absent** (discover-benefits appears to have never committed) and `reddit-state.json` `last_run` is **months stale** (~2026-03) — the exact silent-cron failure. So **verify each working-when against the live Actions run history before trusting any "stays current automatically" claim** (the Core-values "keeps itself current" line is unverified until the run log confirms scheduled runs are firing). A missing/stale state file is the alarm, not noise.
+
 ### Agent state files
 
 Workflows write these; `agent/index.html` reads them to render run history. Never hand-edit — they're regenerated each run.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Grant discovers new programs each week, validates community submissions opened a
 
 ## How it works
 
-Content enters through multiple paths. Humans submit issues; Grant validates and opens a PR. A separate `discover-benefits` workflow searches the web weekly and opens issues for new programs. A `discover-events` workflow finds upcoming student events and creates PRs, removing expired entries automatically. A `maintain-benefits` workflow audits link health every Sunday. A human reviews and merges. Grant cannot publish directly. The merge is the trust boundary.
+Content enters through multiple paths: humans submit issues and Grant validates them, while scheduled workflows discover new programs and events, audit link health, and scout Reddit on their own. Whatever the path, Grant opens a PR — a human reviews and merges. Grant cannot publish directly. The merge is the trust boundary. The full roster of workflows (triggers and what each does) is the table in [`CLAUDE.md`](CLAUDE.md#automated-workflows) — the canonical source.
 
 The **[/agent/](https://student-benefits.github.io/agent/)** page exposes Grant's run log, tool trace, and architecture so the system can be understood and replicated.
 

--- a/agent/agent.js
+++ b/agent/agent.js
@@ -6,9 +6,10 @@ const TOOLS = {
   add_comment:           { actor: 'github', label: 'GitHub',        explain: 'Posts a status comment on the original issue to close the loop with the submitter.' },
   close_issue:           { actor: 'github', label: 'GitHub',        explain: null },
   create_issue:          { actor: 'github', label: 'GitHub',        explain: 'Opens a new GitHub issue for a discovered student program, queuing it for the add-benefit workflow to process.' },
-  tavily_search:         { actor: 'tavily', label: 'Tavily Search', explain: 'Runs a live web search via Tavily to verify the student program exists and find the official signup URL.' },
-  search:                { actor: 'tavily', label: 'Tavily Search', explain: 'Runs a live web search via Tavily to verify the student program exists and find the official signup URL.' }, // alias — MCP tool name varies by server version
-  web_fetch:             { actor: 'web',    label: 'Web',           explain: 'Opens the most relevant search result to confirm the student program details and extract the correct URL.' },
+  'github-issue_read':   { actor: 'github', label: 'GitHub',        explain: 'Reads the GitHub issue to extract the submitted benefit name and any optional details.' },
+  websearch:             { actor: 'web',    label: 'Web Search',    explain: 'Runs a live web search (Claude Code’s built-in WebSearch tool) to verify the student program exists and find the official signup URL.' },
+  web_fetch:             { actor: 'web',    label: 'Web Fetch',     explain: 'Opens the most relevant search result (Claude Code’s built-in WebFetch tool) to confirm the student program details and extract the correct URL.' },
+  webfetch:              { actor: 'web',    label: 'Web Fetch',     explain: 'Opens the most relevant search result (Claude Code’s built-in WebFetch tool) to confirm the student program details and extract the correct URL.' },
   edit:                  { actor: 'grant',  label: 'Grant',         explain: 'Appends the new benefit entry to <code>data/benefits.json</code> in the repository.' },
 };
 
@@ -137,14 +138,13 @@ function renderRun(data) {
 
 function applyPacketRates(tools, outcome) {
   // conn-search and conn-validate: speed encodes call frequency
-  const counts = { tavily: 0, web: 0, github: 0 };
+  const counts = { web: 0, github: 0 };
   for (const t of tools) {
     const actor = (TOOLS[t.name] || {}).actor || 'grant';
-    if (actor === 'tavily') counts.tavily++;
-    else if (actor === 'web') counts.web++;
+    if (actor === 'web') counts.web++;
     else if (actor === 'github') counts.github++;
   }
-  setPacketRate('conn-search',   counts.tavily + counts.web);
+  setPacketRate('conn-search',   counts.web);
   setPacketRate('conn-validate', counts.github);
   // conn-pr: binary — PR either went to reviewer or it didn't
   setPacketRate('conn-pr', outcome === 'accepted' ? 1 : 0);
@@ -165,7 +165,6 @@ function setPacketRate(id, count) {
 const ACTOR_COLOR = {
   grant:  'var(--grant-color)',
   github: 'var(--github-color)',
-  tavily: 'var(--tavily-color)',
   web:    'var(--web-color)',
 };
 
@@ -211,8 +210,8 @@ const SIM_STEPS = [
     annotation: null
   },
   {
-    stepClass: 'actor-tavily', badge: 'badge-tavily', badgeLabel: 'Tavily',
-    headLabel: 'search', detail: 'Adobe Creative Cloud student discount education',
+    stepClass: 'actor-web', badge: 'badge-web', badgeLabel: 'Web',
+    headLabel: 'websearch', detail: 'Adobe Creative Cloud student discount education',
     primary: '5 results found. Top result: <code>adobe.com/creativecloud/plans/student-and-teacher.html</code>',
     annotation: 'Searches the live web to confirm the program is real and currently active. Not just from training data.'
   },

--- a/agent/index.html
+++ b/agent/index.html
@@ -66,9 +66,9 @@
         </div>
 
         <div class="arch-node-wrap arch-node-wrap--stacked">
-          <button class="arch-node arch-node--tavily" id="node-tavily" aria-expanded="false" aria-controls="panel-tavily">
-            <span class="arch-node-label">Tavily</span>
-            <span class="arch-node-sublabel">web search</span>
+          <button class="arch-node arch-node--web" id="node-search" aria-expanded="false" aria-controls="panel-search">
+            <span class="arch-node-label">Web Search</span>
+            <span class="arch-node-sublabel">live results</span>
           </button>
           <button class="arch-node arch-node--web" id="node-web" aria-expanded="false" aria-controls="panel-web">
             <span class="arch-node-label">Web Fetch</span>
@@ -117,13 +117,13 @@
           <p class="node-panel-title">Grant · Claude Sonnet 4.6</p>
           <p>The orchestrator. Grant reads the issue, decides which tools to call, interprets the results, and determines the outcome without human approval of intermediate steps. Its output depends on the workflow and the outcome — a PR, a comment, a closed issue, or a combination. Its instructions are a Markdown file checked into this repository.</p>
         </div>
-        <div id="panel-tavily" class="node-panel" hidden>
-          <p class="node-panel-title">Tavily Search</p>
-          <p>A search API built for AI agents. Grant calls it to verify whether a student program exists by searching the live web beyond its training data. Tavily returns structured results Grant can reason over directly.</p>
+        <div id="panel-search" class="node-panel" hidden>
+          <p class="node-panel-title">Web Search</p>
+          <p>Claude Code’s built-in <code>WebSearch</code> tool. Grant calls it to verify whether a student program exists by searching the live web beyond its training data, returning candidate results Grant can reason over directly.</p>
         </div>
         <div id="panel-web" class="node-panel" hidden>
           <p class="node-panel-title">Web Fetch</p>
-          <p>After Tavily returns candidate URLs, Grant fetches the actual pages to confirm the program is real, active, and has a direct student signup link. Read-only. No forms submitted, no side effects.</p>
+          <p>Claude Code’s built-in <code>WebFetch</code> tool. After Web Search returns candidate URLs, Grant fetches the actual pages to confirm the program is real, active, and has a direct student signup link. Read-only. No forms submitted, no side effects.</p>
         </div>
         <div id="panel-output" class="node-panel" hidden>
           <p class="node-panel-title">GitHub Output</p>
@@ -131,7 +131,7 @@
         </div>
         <div id="panel-human" class="node-panel" hidden>
           <p class="node-panel-title">Human Reviewer</p>
-          <p>Grant cannot merge its own pull requests. Its <code>safe-outputs</code> configuration restricts it to commenting, opening PRs, and closing issues — no write access to <code>main</code>. Grant handles correctness (format, links, duplicates); the reviewer exercises judgment (editorial fit, quality).</p>
+          <p>Grant cannot merge its own pull requests. Each workflow runs with a scoped GitHub Actions <code>permissions:</code> block (<code>contents</code>, <code>issues</code>, <code>pull-requests</code>) — enough to commit to a branch, open a PR, and comment, but not to merge. The merge itself is gated by <code>CODEOWNERS</code> and branch protection, so it stays a human decision. Grant handles correctness (format, links, duplicates); the reviewer exercises judgment (editorial fit, quality).</p>
         </div>
       </div>
     </div>
@@ -175,7 +175,7 @@
     <div class="prop-detail-slot">
       <div id="ppanel-tool" class="node-panel" hidden>
         <p class="node-panel-title">Tool use</p>
-        <p>An agent selects tools based on what it finds, not a fixed sequence. Grant calls GitHub, Tavily, and web fetch in an order that varies with every submission.</p>
+        <p>An agent selects tools based on what it finds, not a fixed sequence. Grant calls GitHub, web search, and web fetch in an order that varies with every submission.</p>
       </div>
       <div id="ppanel-decision" class="node-panel" hidden>
         <p class="node-panel-title">Decision-making</p>

--- a/agent/state/last-events-submission.json
+++ b/agent/state/last-events-submission.json
@@ -5,7 +5,7 @@
   "outcome": "accepted",
   "tools": [
     { "name": "github-issue_read", "summary": "Read issue #112" },
-    { "name": "tavily_search", "query": "Paul Daisy Soros Fellowship New Americans application 2026 2027" },
+    { "name": "websearch", "query": "Paul Daisy Soros Fellowship New Americans application 2026 2027" },
     { "name": "web_fetch", "url": "https://pdsoros.org/" },
     { "name": "web_fetch", "url": "https://pdsoros.org/application-process/" },
     { "name": "edit", "summary": "Added entry to events.json" }

--- a/data/events.json
+++ b/data/events.json
@@ -39,34 +39,6 @@
     "expires": "2026-06-30"
   },
   {
-    "id": "google-io-2026",
-    "name": "Google I/O 2026",
-    "organizer": "Google",
-    "category": "conference",
-    "date": "2026-05-19",
-    "date_end": "2026-05-20",
-    "location": "Mountain View, CA",
-    "remote": false,
-    "eligibility": "Open to all; online attendance is free",
-    "why": "Google's flagship developer conference — free online stream. New APIs and SDKs are announced here first, before documentation catches up.",
-    "link": "https://io.google/2026/",
-    "expires": "2026-05-20"
-  },
-  {
-    "id": "quackhacks-3-2026",
-    "name": "QuackHacks 3",
-    "organizer": "University of Oregon / Major League Hacking",
-    "category": "hackathon",
-    "date": "2026-05-30",
-    "date_end": "2026-05-31",
-    "location": "Eugene, Oregon",
-    "remote": false,
-    "eligibility": "Students worldwide, teams welcome",
-    "why": "Oregon's largest hackathon with $10K+ in prizes. 24-hour build with Google sponsorship, mentorship, and travel reimbursement. Strong track record for launching student projects.",
-    "link": "https://www.quackhacks.org/",
-    "expires": "2026-05-31"
-  },
-  {
     "id": "mcw-young-leaders-fellowship-2026",
     "name": "MCW Global Young Leaders Fellowship 2026",
     "organizer": "MCW Global (Miracle Corners of the World)",


### PR DESCRIPTION
Lens-audit fixes (review-only audit → applied). All working-tree edits, no behavior change to the validator/trust boundary.

## Transparency page de-drift (the `/agent/` page sold "the seams are visible so the system can be replicated" — but documented things that don't exist)
- **Removed the phantom Tavily tool.** `grep -rin tavily` = 0 hits; every workflow uses Claude Code's built-in `WebSearch`/`WebFetch`. The architecture node, explainer panels, and tool-trace mapping now name the real tools.
- **Removed the phantom `safe-outputs` claim.** No such mechanism exists; the real containment is Actions `permissions:` blocks + CODEOWNERS + branch protection (human merge). Rewritten to describe that.
- Retitled the one stale trace still logging `tavily_search`.

## Data + docs
- **Removed 2 expired events** (Google I/O 2026, QuackHacks 3 — both past expiry vs 2026-06-08).
- README workflow roster → pointer to the canonical `CLAUDE.md` table (was drifted, omitted 2 workflows).

## Falsifiability (Jonas's "running systems" convention)
- Added a **working-when + N-cycle teardown** clause to each of the 4 scheduled workflows, phrased as *liveness + positive trace* (never a found-count), so silence-by-design can't falsify. Default N = 8 weekly cycles (~2mo), tune as needed.
- New `CLAUDE.md` "Falsifiability (scheduled workflows)" subsection; criteria live in files (contract), cycle history in the Actions log (state).

## ⚠ Surfaced while doing the above — likely real failures
- **`scout-reddit` appears dead**: `reddit-state.json` `last_run` is stale at ~2026-03-14 (~12 weekly cycles silent, past the proposed N=8).
- **`discover-benefits` has never committed** its `agent/state/last-benefits-discovery.json` (sibling `last-events-discovery.json` exists).
- Worth verifying both against the live Actions run history before trusting the "stays current automatically" claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)