### PR TITLE
Depersonalize and densify docs/context

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-benefit.yml
+++ b/.github/ISSUE_TEMPLATE/new-benefit.yml
@@ -6,15 +6,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Just tell us about the benefit - be as brief or detailed as you like.**
-
-        Our AI will identify the product, find the correct signup URL, and extract all the details. You don't need to be formal or include every detail.
+        **Name the benefit — a few words is enough.** Grant finds the signup URL and extracts the details.
 
   - type: textarea
     id: description
     attributes:
       label: What's the benefit?
-      description: Describe it however you want - a sentence, a few words, or a detailed explanation all work fine.
+      description: A few words or a full description — both work.
       placeholder: |
         Examples of valid submissions:
 

--- a/.github/ISSUE_TEMPLATE/new-event.yml
+++ b/.github/ISSUE_TEMPLATE/new-event.yml
@@ -6,15 +6,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Just tell us about the event — be as brief or detailed as you like.**
-
-        Our AI will find the event page, verify the details, and extract everything it needs. You don't need to fill in dates or categories — just point us to it.
+        **Name the event — a few words is enough.** Grant finds the page and verifies dates, category, and details.
 
   - type: textarea
     id: description
     attributes:
       label: What's the event?
-      description: Describe it however you want — a name, a sentence, or a detailed explanation all work.
+      description: A name or a full description — both work.
       placeholder: |
         Examples of valid submissions:
 

--- a/.github/workflows/discover-benefits.yml
+++ b/.github/workflows/discover-benefits.yml
@@ -6,7 +6,7 @@ name: Discover Student Benefits
 #     nothing met the bar" heartbeat). NOT a found-count: silence-by-design (a dry week) is healthy iff the heartbeat moves.
 #     A run that opens nothing AND doesn't bump the timestamp = the cron silently isn't firing/committing → broken, not empty.
 #   Teardown after N: 8 weekly cycles (~2 months). If working-when is unmet for 8 consecutive Mondays (timestamp never
-#     advances / Actions shows no scheduled runs), the discovery thesis is wrong → remove this workflow. (N is Jonas's to tune.)
+#     advances / Actions shows no scheduled runs), the discovery thesis is wrong → remove this workflow. (N is adjustable.)
 
 on:
   schedule:

--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -7,7 +7,7 @@ name: Discover Student Events
 #     a timestamp that never advances = the cron silently isn't firing → broken, not empty. (Stale events not auto-expiring
 #     is the observable symptom of this being broken.)
 #   Teardown after N: 8 weekly cycles (~2 months). If working-when is unmet for 8 consecutive Wednesdays, the thesis is
-#     wrong → remove this workflow. (N is Jonas's to tune.)
+#     wrong → remove this workflow. (N is adjustable.)
 
 on:
   schedule:

--- a/.github/workflows/maintain-benefits.yml
+++ b/.github/workflows/maintain-benefits.yml
@@ -7,7 +7,7 @@ name: Maintain Benefits
 #     case leaves no artifact, so liveness here is verified primarily from the Actions run log showing the scheduled run ran
 #     green. A Sunday with NO run in the Actions log = the cron silently isn't firing → broken, not empty.
 #   Teardown after N: 8 weekly cycles (~2 months). If no scheduled run appears for 8 consecutive Sundays, the
-#     auto-maintenance thesis is wrong → remove this workflow. (N is Jonas's to tune.)
+#     auto-maintenance thesis is wrong → remove this workflow. (N is adjustable.)
 
 on:
   schedule:

--- a/.github/workflows/pr-concierge.yml
+++ b/.github/workflows/pr-concierge.yml
@@ -44,6 +44,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Maintainer handle comes from CODEOWNERS (single source) — not hardcoded.
+          owner=$(gh api "repos/$GITHUB_REPOSITORY/contents/.github/CODEOWNERS" \
+            --jq '.content' | base64 -d | grep -oE '@[A-Za-z0-9-]+' | head -1 | tr -d '@')
+          [ -n "$owner" ] || { echo "no CODEOWNERS owner found"; exit 1; }
+
           # A PR is "ready" when, ignoring drafts / the maintainer's own PRs /
           # already-flagged PRs, every check is positively green. The rollup is a
           # union: GitHub Actions emit CheckRun (.status + .conclusion); legacy
@@ -53,7 +58,7 @@ jobs:
           # the ping (it sometimes errors), so a green PR is never stuck on it.
           ready=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 200 \
             --json number,title,isDraft,author,labels,statusCheckRollup,reviews \
-            | jq -c '
+            | jq -c --arg owner "$owner" '
               def copilot:
                 ([.reviews[]? | select(.author.login=="copilot-pull-request-reviewer")] | last);
               def bad:   (.conclusion // .state) as $x
@@ -70,7 +75,7 @@ jobs:
                   else "ok" end;
               .[]
               | select(.isDraft | not)
-              | select(.author.login != "jonasneves")
+              | select(.author.login != $owner)
               | select([.labels[]?.name] | index("ready-for-review") | not)
               | { number, title, ci: ci,
                   cilabel: (if ((.statusCheckRollup // []) | length) == 0
@@ -94,7 +99,7 @@ jobs:
             num=$(echo "$pr"     | jq -r .number)
             cilabel=$(echo "$pr" | jq -r .cilabel)
             copilot=$(echo "$pr" | jq -r .copilot)
-            body=$(printf '@jonasneves Ready for review — %s · Copilot: %s\n\n<sub>Auto-flagged by PR Concierge: required checks are green. The merge call is yours.</sub>' "$cilabel" "$copilot")
+            body="@$owner ready for review — $cilabel · Copilot: $copilot"
 
             if [ "$DRY_RUN" = "true" ]; then
               echo "[dry-run] would flag #$num (CI: $cilabel; Copilot: $copilot)"

--- a/.github/workflows/scout-reddit.yml
+++ b/.github/workflows/scout-reddit.yml
@@ -7,7 +7,7 @@ name: Scout Reddit
 #     still advances. A `last_run` that doesn't move week-over-week = the cron silently isn't firing/committing → broken,
 #     not empty. (As of this writing `last_run` is months stale — exactly the silent-cron failure to verify.)
 #   Teardown after N: 8 weekly cycles (~2 months). If `last_run` never advances across 8 consecutive Fridays, the
-#     Reddit-signal thesis is wrong → remove this workflow. (N is Jonas's to tune.)
+#     Reddit-signal thesis is wrong → remove this workflow. (N is adjustable.)
 
 on:
   schedule:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,12 @@ and architecture. The seams are visible by design so the system can be
 understood and replicated. When working on this project, preserve that
 transparency: keep workflows documented, keep the agent page accurate.
 
+**Impersonal, dense docs.** No personal name or narrative voice in docs, context,
+or agent surfaces. Maintainer identity lives once, in CODEOWNERS — reference it as
+"the maintainer", never a restated handle. Functional handles are excepted (the
+CODEOWNERS list itself, the @-mention that triggers a notification, the LICENSE
+legal name). Maximize meaning per token: cut hedging, restatement, ceremony.
+
 Keep `agent/index.html` in sync with Grant's behavior — workflow logic,
 validation rules, schema, trigger conditions. Mismatch is a bug.
 
@@ -117,7 +123,7 @@ Each workflow is a plain GitHub Actions YAML in `.github/workflows/`. The agent 
 | `maintain-benefits.yml` | Weekly (Sunday) or manual | Audits link health and quality, fixes findings, opens one PR |
 | `scout-reddit.yml` | Weekly (Friday) or manual | Scouts Reddit (`site:reddit.com` searches) for benefit mentions (`MODE=discover`) and posting opportunities (`MODE=scout`, → Discord via the `DISCORD_WEBHOOK_URL` secret). State in `agent/state/reddit-state.json`; `DRY_RUN=true` skips writes and the webhook. |
 | `validate-data.yml` | PR touching `data/` or the validator | Runs `scripts/validate_data.py` — the deterministic data-integrity gate. |
-| `pr-concierge.yml` | Daily (13:00 UTC) or manual | Sweeps open PRs; once a PR's required checks are green, posts one `@jonasneves` comment and labels it `ready-for-review` (idempotent dedup marker). Surfaces Copilot's verdict in the comment but gates only on CI; never merges. Deterministic — no LLM. |
+| `pr-concierge.yml` | Daily (13:00 UTC) or manual | Sweeps open PRs; once a PR's required checks are green, @-mentions the maintainer (from CODEOWNERS) and labels it `ready-for-review` (idempotent dedup marker). Surfaces Copilot's verdict but gates only on CI; never merges. Deterministic — no LLM. |
 
 Edit a workflow's `prompt:` directly to change Grant's behavior — no compile step.
 
@@ -127,7 +133,7 @@ No router/orchestrator yet: the two label-triggered workflows (add-benefit, add-
 
 ### Falsifiability (scheduled workflows)
 
-Every cron workflow carries, in its YAML, a **working-when** criterion + an **N-cycle teardown** clause (the "running systems" convention). **Criteria are contract** (in the files); **cycle history is state** (the Actions run log) — don't restate run history here. The criteria are silence-tolerant by design: these are discovery/maintenance surfacers that *may legitimately find nothing* some weeks, so the test is **the pipeline being alive**, never an output count. Working-when = a scheduled run *completes and leaves a positive trace of having looked* (an issue/PR, or a dated heartbeat in its state file). Default N = **8 weekly cycles (~2 months)** for each; Jonas's to tune.
+Every cron workflow carries, in its YAML, a **working-when** criterion + an **N-cycle teardown** clause (the "running systems" convention). **Criteria are contract** (in the files); **cycle history is state** (the Actions run log) — don't restate run history here. The criteria are silence-tolerant by design: these are discovery/maintenance surfacers that *may legitimately find nothing* some weeks, so the test is **the pipeline being alive**, never an output count. Working-when = a scheduled run *completes and leaves a positive trace of having looked* (an issue/PR, or a dated heartbeat in its state file). Default N = **8 weekly cycles (~2 months)**, adjustable per workflow.
 
 | Workflow | Working-when (positive trace) | N |
 |---|---|---|
@@ -190,8 +196,8 @@ gh workflow run maintain-benefits.yml --repo student-benefits/student-benefits.g
 - All changes go through PRs — never push directly to `main`
 - PRs must have a written Summary (not just a template placeholder)
 - GitHub Pages serves the site directly from the `main` branch root
-- Every PR automatically requests review from @jonasneves (via CODEOWNERS)
-- Branch protection requires @jonasneves approval before any PR can merge
+- Every PR automatically requests review from the maintainer (via CODEOWNERS)
+- Branch protection requires maintainer approval (CODEOWNERS) before any PR can merge
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Grant discovers new programs each week, validates community submissions opened a
 
 ## How it works
 
-Content enters through multiple paths: humans submit issues and Grant validates them, while scheduled workflows discover new programs and events, audit link health, and scout Reddit on their own. Whatever the path, Grant opens a PR — a human reviews and merges. Grant cannot publish directly. The merge is the trust boundary. The full roster of workflows (triggers and what each does) is the table in [`CLAUDE.md`](CLAUDE.md#automated-workflows) — the canonical source.
+Content enters through multiple paths: humans submit issues and Grant validates them, while scheduled workflows discover new programs and events, audit link health, and scout Reddit on their own. Whatever the path, Grant opens a PR; a human reviews and merges. The full roster of workflows (triggers and what each does) is the table in [`CLAUDE.md`](CLAUDE.md#automated-workflows) — the canonical source.
 
 The **[/agent/](https://student-benefits.github.io/agent/)** page exposes Grant's run log, tool trace, and architecture so the system can be understood and replicated.
 


### PR DESCRIPTION
## Summary

Removes personal name and narrative voice from all docs, context, and workflow comments. Only **functional** name references remain — the CODEOWNERS routing primitive, the @-mention that triggers a notification, and the LICENSE legal name. Adds a durable convention so it doesn't recur.

Triggered by `CLAUDE.md`'s "Jonas's to tune" and the founder-voice in the concierge comment; a full audit (both axes — name/narrative + core-value density) surfaced the rest.

## Changes
- **`CLAUDE.md`** — 4 name sites → "the maintainer (CODEOWNERS)" (single source, no drift-prone restated handle); dropped "Jonas's to tune"; new **"Impersonal, dense docs"** core value codifying the rule + the functional-handle exception.
- **`pr-concierge.yml`** — maintainer handle now **derived from CODEOWNERS** at runtime (no hardcoded name in the workflow); comment collapsed to one dense line; founder-voice footer cut (the `ready-for-review` label already encodes it).
- **`discover-benefits` / `discover-events` / `maintain-benefits` / `scout-reddit`** — `(N is Jonas's to tune.)` → `(N is adjustable.)` in the falsifiability headers.
- **`README.md`** — cut the trust-boundary sentence duplicated from the lede.
- **Issue templates** — collapsed the thrice-restated "low effort is fine" reassurance to one line each.

## Validation
- `git grep -i jonas` (excluding JSON) → only `CODEOWNERS` + `LICENSE` remain; narrative-phrase sweep clean.
- All touched workflow YAML re-parses.
- Concierge: maintainer correctly derived from CODEOWNERS (`jonasneves`); sweep classification unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)