### PR TITLE
Harden add-benefit: keep benefits.json id-sorted to avoid merge cascades

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -93,7 +93,7 @@ jobs:
 
             ## Step 5: Write files
 
-            Append the entry to `data/benefits.json` (preserve 2-space indent, trailing newline).
+            Insert the entry into `data/benefits.json` in its `id`-sorted position — the file is kept sorted by `id` (ascending), and CI rejects out-of-order entries. Do NOT append to the end. Preserve 2-space indent and trailing newline.
 
             Replace `agent/state/last-run.json` entirely with:
             ```json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,12 @@ benefits — all data must go through this file.
 - `popularity`: integer 1–10; use 5 as default for new entries
 - `repo`: optional; only for open-source projects
 
+Entries are sorted by `id` (ascending); the validator enforces it. Insert new
+entries in sorted position — never append to the end. (Sorted insertion spreads
+concurrent additions across the file, so a burst of add-benefit PRs auto-merges
+instead of all colliding at the array tail. Display order is unaffected — the UI
+re-sorts client-side by popularity.)
+
 ---
 
 ## Source of truth: `data/events.json`

--- a/data/benefits.json
+++ b/data/benefits.json
@@ -1,77 +1,5 @@
 [
   {
-    "id": "github-student-pack",
-    "name": "GitHub Student Developer Pack",
-    "category": "Dev Tools",
-    "offer_type": "free",
-    "description": "100+ free tools including Copilot Pro, JetBrains IDEs, DigitalOcean credits, domains, and more.",
-    "link": "https://education.github.com/pack",
-    "tags": [
-      "Free Tools",
-      "Dev Pack",
-      "Essential"
-    ],
-    "popularity": 10
-  },
-  {
-    "id": "github-copilot",
-    "name": "GitHub Copilot Pro",
-    "category": "AI Tools",
-    "offer_type": "free",
-    "description": "Free Copilot Pro while you're a student. AI pair programmer with unlimited completions and chat.",
-    "link": "https://github.com/education/students",
-    "tags": [
-      "AI",
-      "Coding",
-      "GitHub"
-    ],
-    "popularity": 10
-  },
-  {
-    "id": "cursor-pro",
-    "name": "Cursor Pro",
-    "category": "AI Tools",
-    "offer_type": "free",
-    "description": "Free year of Cursor Pro for verified university students. AI code editor with 500 fast requests/month.",
-    "link": "https://cursor.com/students",
-    "tags": [
-      "AI",
-      "Editor",
-      "IDE"
-    ],
-    "popularity": 9,
-    "repo": "getcursor/cursor"
-  },
-  {
-    "id": "jetbrains-ides",
-    "name": "JetBrains IDEs",
-    "category": "Dev Tools",
-    "offer_type": "free",
-    "description": "Free access to all JetBrains professional IDEs (IntelliJ, PyCharm, WebStorm, etc.). Renewable annually.",
-    "link": "https://www.jetbrains.com/community/education/#students",
-    "tags": [
-      "IDE",
-      "Programming",
-      "Java"
-    ],
-    "popularity": 9,
-    "repo": "JetBrains/intellij-community"
-  },
-  {
-    "id": "perplexity-pro",
-    "name": "Perplexity Pro",
-    "category": "AI Tools",
-    "offer_type": "discount",
-    "description": "50% off Pro for students with .edu email. Includes Study Mode, unlimited uploads, and Research Mode.",
-    "link": "https://www.perplexity.ai/students",
-    "tags": [
-      "AI",
-      "Search",
-      "Research"
-    ],
-    "popularity": 8
-  },
-  {
     "id": "1password",
     "name": "1Password",
     "category": "Security",
@@ -86,174 +14,47 @@
     "popularity": 8
   },
   {
-    "id": "microsoft-azure",
-    "name": "Microsoft Azure",
-    "category": "Cloud & Hosting",
-    "offer_type": "credits",
-    "description": "$100 free credits yearly (renewable while enrolled), no credit card required. 55+ Azure services.",
-    "link": "https://azure.microsoft.com/en-us/free/students",
+    "id": "adafruit",
+    "name": "Adafruit",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free 1-year Adafruit IO+ membership and 30% off select Circuit Playground hardware.",
+    "link": "https://www.adafruit.com/github-students",
     "tags": [
-      "Azure",
-      "Microsoft",
-      "Cloud"
+      "Hardware",
+      "IoT",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "adobe-creative-cloud",
+    "name": "Adobe Creative Cloud",
+    "category": "Design",
+    "offer_type": "discount",
+    "description": "60%+ off 20+ apps including Photoshop, Illustrator, and Premiere. $19.99/month for the first year.",
+    "link": "https://www.adobe.com/creativecloud/buy/students.html",
+    "tags": [
+      "Design",
+      "Photography",
+      "Video",
+      "Creative"
     ],
     "popularity": 9
   },
   {
-    "id": "aws-educate",
-    "name": "AWS Educate",
-    "category": "Cloud & Hosting",
-    "offer_type": "credits",
-    "description": "$100 in AWS credits for students, no credit card required. Access to hands-on labs, learning paths, and job board.",
-    "link": "https://aws.amazon.com/education/awseducate/",
-    "tags": [
-      "AWS",
-      "Cloud",
-      "Learning"
-    ],
-    "popularity": 9
-  },
-  {
-    "id": "mongodb-atlas",
-    "name": "MongoDB Atlas",
-    "category": "Cloud & Hosting",
-    "offer_type": "credits",
-    "description": "$50 in credits plus free MongoDB University access via GitHub Student Pack. Cloud database with generous free tier.",
-    "link": "https://www.mongodb.com/students",
+    "id": "airtable-student",
+    "name": "Airtable Student",
+    "category": "Productivity",
+    "offer_type": "free",
+    "description": "Free Team plan for 6-24 months. Instant 120-day trial with .edu email, then apply for extended access.",
+    "link": "https://www.airtable.com/solutions/education",
     "tags": [
       "Database",
-      "NoSQL",
-      "Cloud"
+      "No-Code",
+      "Spreadsheet"
     ],
-    "popularity": 7,
-    "repo": "mongodb/mongo"
-  },
-  {
-    "id": "heroku",
-    "name": "Heroku",
-    "category": "Cloud & Hosting",
-    "offer_type": "credits",
-    "description": "$13/month platform credit for 24 months via GitHub Student Pack. Easy app deployment with managed infrastructure.",
-    "link": "https://www.heroku.com/github-students",
-    "tags": [
-      "PaaS",
-      "Hosting",
-      "GitHub"
-    ],
-    "popularity": 6
-  },
-  {
-    "id": "figma",
-    "name": "Figma Education",
-    "category": "Design",
-    "offer_type": "free",
-    "description": "Free Figma Professional for 2 years. Unlimited files, version history, and team libraries. Verify with school email.",
-    "link": "https://www.figma.com/education/",
-    "tags": [
-      "Design",
-      "UI/UX",
-      "Collaboration"
-    ],
-    "popularity": 10
-  },
-  {
-    "id": "canva",
-    "name": "Canva for Education",
-    "category": "Design",
-    "offer_type": "free",
-    "description": "Free Pro with .edu email. Premium templates, stock content, brand kit, and collaboration tools for students.",
-    "link": "https://www.canva.com/education/students/",
-    "tags": [
-      "Design",
-      "Graphics",
-      "Marketing"
-    ],
-    "popularity": 9
-  },
-  {
-    "id": "autodesk",
-    "name": "Autodesk",
-    "category": "Design",
-    "offer_type": "free",
-    "description": "Free 1-year access to AutoCAD, Revit, Maya, 3ds Max, Fusion, and 100+ products. Renewable while enrolled.",
-    "link": "https://www.autodesk.com/education/home",
-    "tags": [
-      "3D",
-      "CAD",
-      "Engineering"
-    ],
-    "popularity": 8
-  },
-  {
-    "id": "notion",
-    "name": "Notion Education",
-    "category": "Productivity",
-    "offer_type": "free",
-    "description": "Free Plus plan with unlimited blocks, file uploads, and 30-day version history. Just sign in with your .edu email.",
-    "link": "https://www.notion.so/product/notion-for-education",
-    "tags": [
-      "Notes",
-      "Planning",
-      "Knowledge"
-    ],
-    "popularity": 10
-  },
-  {
-    "id": "obsidian",
-    "name": "Obsidian",
-    "category": "Productivity",
-    "offer_type": "discount",
-    "description": "App is free for everyone. Students get 40% off Sync ($29/year) and Publish for cloud backup and publishing.",
-    "link": "https://obsidian.md/pricing",
-    "tags": [
-      "Notes",
-      "Markdown",
-      "PKM"
-    ],
-    "popularity": 9,
-    "repo": "obsidianmd/obsidian-releases"
-  },
-  {
-    "id": "grammarly",
-    "name": "Grammarly",
-    "category": "Productivity",
-    "offer_type": "discount",
-    "description": "Student discounts available via SheerID/UNiDAYS verification. Free Premium tier plus AI features for students.",
-    "link": "https://www.grammarly.com/students",
-    "tags": [
-      "Writing",
-      "AI",
-      "Grammar"
-    ],
-    "popularity": 8
-  },
-  {
-    "id": "microsoft-365",
-    "name": "Microsoft 365 Education",
-    "category": "Productivity",
-    "offer_type": "free",
-    "description": "Free Word, Excel, PowerPoint, OneNote, Teams, and 1TB OneDrive storage with valid school email address.",
-    "link": "https://www.microsoft.com/en-us/education/products/office",
-    "tags": [
-      "Office",
-      "Documents",
-      "Microsoft"
-    ],
-    "popularity": 9
-  },
-  {
-    "id": "spotify-student",
-    "name": "Spotify Premium Student",
-    "category": "Lifestyle",
-    "offer_type": "discount",
-    "description": "$6.99/month (50% off) with Hulu included. Ad-free music, offline downloads, unlimited skips. Valid for up to 4 years.",
-    "link": "https://www.spotify.com/us/student/",
-    "tags": [
-      "Music",
-      "Streaming",
-      "Hulu"
-    ],
-    "popularity": 10
+    "popularity": 7
   },
   {
     "id": "amazon-prime-student",
@@ -284,47 +85,6 @@
     "popularity": 9
   },
   {
-    "id": "unidays",
-    "name": "UNiDAYS",
-    "category": "Lifestyle",
-    "offer_type": "discount",
-    "description": "Free access to hundreds of verified student discounts on fashion, tech, food, travel, and entertainment.",
-    "link": "https://www.myunidays.com/US/en-US/account/register",
-    "tags": [
-      "Discounts",
-      "Shopping"
-    ],
-    "popularity": 8
-  },
-  {
-    "id": "google-gemini-pro",
-    "name": "Google Gemini Pro",
-    "category": "AI Tools",
-    "offer_type": "free",
-    "description": "Free 12-month Google AI Pro for students. Includes Gemini 2.5 Pro, Deep Research, and NotebookLM Plus.",
-    "link": "https://gemini.google/students/",
-    "tags": [
-      "AI",
-      "Google",
-      "Research"
-    ],
-    "popularity": 10
-  },
-  {
-    "id": "google-cloud",
-    "name": "Google Cloud Credits",
-    "category": "Cloud & Hosting",
-    "offer_type": "credits",
-    "description": "$300 free credits for students plus always-free tier. Access through Google for Education or the standard free trial.",
-    "link": "https://cloud.google.com/edu/students",
-    "tags": [
-      "Cloud",
-      "Google",
-      "GCP"
-    ],
-    "popularity": 9
-  },
-  {
     "id": "apple-music-student",
     "name": "Apple Music Student",
     "category": "Lifestyle",
@@ -339,241 +99,33 @@
     "popularity": 9
   },
   {
-    "id": "youtube-premium-student",
-    "name": "YouTube Premium Student",
-    "category": "Lifestyle",
-    "offer_type": "discount",
-    "description": "$7.99/month (50% off). Ad-free videos, offline downloads, YouTube Music included. Valid up to 4 years.",
-    "link": "https://www.youtube.com/premium/student",
-    "tags": [
-      "Video",
-      "Streaming",
-      "Music"
-    ],
-    "popularity": 9
-  },
-  {
-    "id": "cloudflare-workers",
-    "name": "Cloudflare Workers",
+    "id": "appwrite",
+    "name": "Appwrite Education",
     "category": "Cloud & Hosting",
     "offer_type": "free",
-    "description": "Free Workers Paid Plan for 1 year. Includes Workers, Pages Functions, KV, and Durable Objects.",
-    "link": "https://www.cloudflare.com/students/",
+    "description": "Free Pro plan with 2 projects while enrolled via GitHub Student Pack. Worth $40/month.",
+    "link": "https://appwrite.io/education",
     "tags": [
-      "Serverless",
-      "Edge",
-      "Hosting"
+      "Backend",
+      "BaaS",
+      "GitHub Student Pack"
     ],
-    "popularity": 8
+    "popularity": 5
   },
   {
-    "id": "unity-student",
-    "name": "Unity Student",
-    "category": "Design",
-    "offer_type": "free",
-    "description": "Free Unity Pro features for students. Includes Odin Inspector license and 20% off assets. Renewable.",
-    "link": "https://unity.com/products/unity-student",
-    "tags": [
-      "Game Dev",
-      "3D",
-      "Engine"
-    ],
-    "popularity": 8
-  },
-  {
-    "id": "miro-education",
-    "name": "Miro Education",
-    "category": "Productivity",
-    "offer_type": "free",
-    "description": "Free for 2 years. Unlimited boards, high-res exports, and custom templates. Apply with student documentation.",
-    "link": "https://miro.com/education-whiteboard/",
-    "tags": [
-      "Whiteboard",
-      "Collaboration",
-      "Planning"
-    ],
-    "popularity": 8
-  },
-  {
-    "id": "sketch",
-    "name": "Sketch",
-    "category": "Design",
-    "offer_type": "free",
-    "description": "Free for 1 year. Professional UI/UX design tool for Mac with prototyping, collaboration, and plugins.",
-    "link": "https://www.sketch.com/education/",
-    "tags": [
-      "Design",
-      "UI/UX",
-      "Mac"
-    ],
-    "popularity": 7
-  },
-  {
-    "id": "loom-education",
-    "name": "Loom Education",
-    "category": "Productivity",
-    "offer_type": "discount",
-    "description": "50-75% off Loom for verified students and educators. Unlimited recordings, HD quality, and full editing tools.",
-    "link": "https://www.loom.com/use-case/education",
-    "tags": [
-      "Video",
-      "Recording",
-      "Communication"
-    ],
-    "popularity": 7
-  },
-  {
-    "id": "postman-student",
-    "name": "Postman Student Expert",
-    "category": "Learning",
-    "offer_type": "free",
-    "description": "Free API training and certification. Learn API fundamentals, earn a digital badge, and join the community.",
-    "link": "https://academy.postman.com/page/students",
-    "tags": [
-      "API",
-      "Certification",
-      "Dev Tools"
-    ],
-    "popularity": 8
-  },
-  {
-    "id": "ibm-skillsbuild",
-    "name": "IBM SkillsBuild",
-    "category": "Learning",
-    "offer_type": "free",
-    "description": "Free 1000+ courses in AI, cybersecurity, cloud, and data science. Earn industry-recognized credentials.",
-    "link": "https://skillsbuild.org/students",
-    "tags": [
-      "Courses",
-      "Certifications",
-      "IBM"
-    ],
-    "popularity": 8
-  },
-  {
-    "id": "gitkraken",
-    "name": "GitKraken",
+    "id": "arduino-cloud",
+    "name": "Arduino Cloud",
     "category": "Dev Tools",
     "offer_type": "trial",
-    "description": "6 months free via GitHub Student Pack, then 80% off while a student. Git GUI client with GitLens VS Code extension.",
-    "link": "https://www.gitkraken.com/github-student-developer-pack-bundle",
+    "description": "Free 6-month Arduino Cloud Maker Plan plus hardware discounts (25–50% off select boards) via GitHub Student Pack.",
+    "link": "https://www.arduino.cc/github/students",
     "tags": [
-      "Git",
-      "GitHub",
-      "Dev Tools"
-    ],
-    "popularity": 7
-  },
-  {
-    "id": "educative",
-    "name": "Educative.io",
-    "category": "Learning",
-    "offer_type": "free",
-    "description": "6 months free via GitHub Student Pack. 70+ interactive courses on programming, system design, and interviews.",
-    "link": "https://www.educative.io/github-students",
-    "tags": [
-      "Courses",
-      "Interview Prep",
-      "GitHub"
-    ],
-    "popularity": 8
-  },
-  {
-    "id": "student-beans",
-    "name": "Student Beans",
-    "category": "Lifestyle",
-    "offer_type": "discount",
-    "description": "Free platform with 10,000+ student discounts on fashion, tech, food, and travel. Digital student ID included.",
-    "link": "https://www.studentbeans.com/us",
-    "tags": [
-      "Discounts",
-      "Shopping"
-    ],
-    "popularity": 8
-  },
-  {
-    "id": "airtable-student",
-    "name": "Airtable Student",
-    "category": "Productivity",
-    "offer_type": "free",
-    "description": "Free Team plan for 6-24 months. Instant 120-day trial with .edu email, then apply for extended access.",
-    "link": "https://www.airtable.com/solutions/education",
-    "tags": [
-      "Database",
-      "No-Code",
-      "Spreadsheet"
-    ],
-    "popularity": 7
-  },
-  {
-    "id": "hack-the-box",
-    "name": "Hack The Box Student",
-    "category": "Learning",
-    "offer_type": "discount",
-    "description": "10-20% off student subscription for cybersecurity training. Hands-on labs, challenges, and career-focused content.",
-    "link": "https://academy.hackthebox.com/billing",
-    "tags": [
-      "Cybersecurity",
-      "Hacking",
-      "Labs"
-    ],
-    "popularity": 7
-  },
-  {
-    "id": "tryhackme",
-    "name": "TryHackMe Student",
-    "category": "Learning",
-    "offer_type": "discount",
-    "description": "20% off annual subscription. Beginner-friendly cybersecurity training with guided learning paths and virtual labs.",
-    "link": "https://tryhackme.com/discounts",
-    "tags": [
-      "Cybersecurity",
-      "Learning",
-      "Labs"
-    ],
-    "popularity": 7
-  },
-  {
-    "id": "samsung-education",
-    "name": "Samsung Education",
-    "category": "Lifestyle",
-    "offer_type": "discount",
-    "description": "Up to 30% off Galaxy phones, tablets, laptops, and accessories. Verify with .edu email or ID.me.",
-    "link": "https://www.samsung.com/us/shop/offer-program/education/",
-    "tags": [
+      "IoT",
       "Hardware",
-      "Phones",
-      "Laptops"
+      "Cloud",
+      "GitHub Student Pack"
     ],
-    "popularity": 8
-  },
-  {
-    "id": "evernote-student",
-    "name": "Evernote Student",
-    "category": "Productivity",
-    "offer_type": "discount",
-    "description": "40% off Evernote Professional via UNiDAYS verification. Note-taking with AI search, PDF annotation, and sync.",
-    "link": "https://evernote.com/unidays",
-    "tags": [
-      "Notes",
-      "Organization",
-      "Productivity"
-    ],
-    "popularity": 6
-  },
-  {
-    "id": "raycast-pro",
-    "name": "Raycast Pro",
-    "category": "Productivity",
-    "offer_type": "discount",
-    "description": "50% student discount ($5/month). Mac productivity launcher with AI, cloud sync, and custom themes.",
-    "link": "https://www.raycast.com/pricing",
-    "tags": [
-      "Mac",
-      "Productivity",
-      "AI"
-    ],
-    "popularity": 7
+    "popularity": 5
   },
   {
     "id": "asana-student",
@@ -590,58 +142,172 @@
     "popularity": 7
   },
   {
-    "id": "oracle-cloud",
-    "name": "Oracle Cloud",
+    "id": "autodesk",
+    "name": "Autodesk",
+    "category": "Design",
+    "offer_type": "free",
+    "description": "Free 1-year access to AutoCAD, Revit, Maya, 3ds Max, Fusion, and 100+ products. Renewable while enrolled.",
+    "link": "https://www.autodesk.com/education/home",
+    "tags": [
+      "3D",
+      "CAD",
+      "Engineering"
+    ],
+    "popularity": 8
+  },
+  {
+    "id": "aws-educate",
+    "name": "AWS Educate",
     "category": "Cloud & Hosting",
     "offer_type": "credits",
-    "description": "$300 free credits plus always-free tier via Oracle Academy. Includes Autonomous Database, VMs, and storage.",
-    "link": "https://academy.oracle.com/en/solutions-cloud-program.html",
+    "description": "$100 in AWS credits for students, no credit card required. Access to hands-on labs, learning paths, and job board.",
+    "link": "https://aws.amazon.com/education/awseducate/",
     "tags": [
+      "AWS",
       "Cloud",
-      "Database",
-      "Enterprise"
+      "Learning"
     ],
-    "popularity": 6
+    "popularity": 9
   },
   {
-    "id": "nvidia-education",
-    "name": "NVIDIA Education",
+    "id": "boot-dev",
+    "name": "Boot.dev",
     "category": "Learning",
-    "offer_type": "discount",
-    "description": "Academic GPU discounts, free DLI courses, and research grants. Reduced prices on Jetson developer kits.",
-    "link": "https://developer.nvidia.com/higher-education-and-research",
-    "tags": [
-      "GPU",
-      "AI",
-      "Hardware"
-    ],
-    "popularity": 7
-  },
-  {
-    "id": "red-hat-developer",
-    "name": "Red Hat Developer",
-    "category": "Cloud & Hosting",
     "offer_type": "free",
-    "description": "Free RHEL subscription for up to 16 systems. Full access to updates and self-service support. Renewable annually.",
-    "link": "https://developers.redhat.com/register",
+    "description": "Free 3 months of backend development curriculum (Python, Go, TypeScript).",
+    "link": "https://www.boot.dev/pricing",
     "tags": [
-      "Linux",
-      "Enterprise",
-      "DevOps"
+      "GitHub Student Pack",
+      "Backend",
+      "Courses"
     ],
-    "popularity": 6
+    "popularity": 5
   },
   {
-    "id": "termius-pro",
-    "name": "Termius Pro",
+    "id": "bootstrap-studio",
+    "name": "Bootstrap Studio",
+    "category": "Design",
+    "offer_type": "free",
+    "description": "Free desktop app license for building responsive Bootstrap websites while enrolled.",
+    "link": "https://bootstrapstudio.io/students",
+    "tags": [
+      "Web Design",
+      "Bootstrap",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "browserstack",
+    "name": "BrowserStack",
     "category": "Dev Tools",
     "offer_type": "free",
-    "description": "Free Pro and Team features via GitHub Student Pack. SSH client with sync, SFTP, and team sharing.",
-    "link": "https://termius.com/education",
+    "description": "Free 1-year Live and Automate Mobile plan (worth $2,388). Test on 3,000+ real browsers and devices.",
+    "link": "https://www.browserstack.com/github-students",
     "tags": [
-      "SSH",
-      "Terminal",
-      "GitHub"
+      "Testing",
+      "Browsers",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "canva",
+    "name": "Canva for Education",
+    "category": "Design",
+    "offer_type": "free",
+    "description": "Free Pro with .edu email. Premium templates, stock content, brand kit, and collaboration tools for students.",
+    "link": "https://www.canva.com/education/students/",
+    "tags": [
+      "Design",
+      "Graphics",
+      "Marketing"
+    ],
+    "popularity": 9
+  },
+  {
+    "id": "clerk",
+    "name": "Clerk",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free Pro plan until graduation ($240/yr value) — 50K MAUs, MFA, SSO, and Organizations.",
+    "link": "https://clerk.com/github-student-developer-pack",
+    "tags": [
+      "Authentication",
+      "Identity",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "cloudflare-workers",
+    "name": "Cloudflare Workers",
+    "category": "Cloud & Hosting",
+    "offer_type": "free",
+    "description": "Free Workers Paid Plan for 1 year. Includes Workers, Pages Functions, KV, and Durable Objects.",
+    "link": "https://www.cloudflare.com/students/",
+    "tags": [
+      "Serverless",
+      "Edge",
+      "Hosting"
+    ],
+    "popularity": 8
+  },
+  {
+    "id": "codecov",
+    "name": "Codecov",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free code coverage forever on public and private repositories. Included in GitHub Student Pack.",
+    "link": "https://about.codecov.io/solution/students",
+    "tags": [
+      "Code Coverage",
+      "Testing",
+      "CI/CD",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "codedex",
+    "name": "Codédex",
+    "category": "Learning",
+    "offer_type": "free",
+    "description": "Free 6-month Codédex Club premium with interactive Python, JavaScript, HTML/CSS, and Git courses.",
+    "link": "https://www.codedex.io/github-students",
+    "tags": [
+      "GitHub Student Pack",
+      "Coding",
+      "Courses"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "cursor-pro",
+    "name": "Cursor Pro",
+    "category": "AI Tools",
+    "offer_type": "free",
+    "description": "Free year of Cursor Pro for verified university students. AI code editor with 500 fast requests/month.",
+    "link": "https://cursor.com/students",
+    "tags": [
+      "AI",
+      "Editor",
+      "IDE"
+    ],
+    "popularity": 9,
+    "repo": "getcursor/cursor"
+  },
+  {
+    "id": "dashlane",
+    "name": "Dashlane",
+    "category": "Security",
+    "offer_type": "free",
+    "description": "Free Premium for 1 year with student email. Password manager with auto-login and dark web monitoring.",
+    "link": "https://www.dashlane.com/students",
+    "tags": [
+      "Passwords",
+      "Security",
+      "GitHub Student Pack"
     ],
     "popularity": 5
   },
@@ -660,15 +326,15 @@
     "popularity": 5
   },
   {
-    "id": "appwrite",
-    "name": "Appwrite Education",
-    "category": "Cloud & Hosting",
+    "id": "datadog",
+    "name": "Datadog",
+    "category": "Dev Tools",
     "offer_type": "free",
-    "description": "Free Pro plan with 2 projects while enrolled via GitHub Student Pack. Worth $40/month.",
-    "link": "https://appwrite.io/education",
+    "description": "Free Pro for 2 years. Monitor 10 hosts, 500 GB logs, 1,000 browser tests, 15-month data retention.",
+    "link": "https://studentpack.datadoghq.com/signup",
     "tags": [
-      "Backend",
-      "BaaS",
+      "Monitoring",
+      "Observability",
       "GitHub Student Pack"
     ],
     "popularity": 5
@@ -689,20 +355,6 @@
     "popularity": 5
   },
   {
-    "id": "localstack",
-    "name": "LocalStack",
-    "category": "Dev Tools",
-    "offer_type": "free",
-    "description": "Free AWS emulator with all services, 1,000 monthly CI/CD credits via GitHub Student Pack.",
-    "link": "https://www.localstack.cloud/localstack-for-students",
-    "tags": [
-      "AWS",
-      "Cloud",
-      "GitHub Student Pack"
-    ],
-    "popularity": 5
-  },
-  {
     "id": "doppler",
     "name": "Doppler",
     "category": "Security",
@@ -718,16 +370,58 @@
     "popularity": 5
   },
   {
-    "id": "boot-dev",
-    "name": "Boot.dev",
+    "id": "educative",
+    "name": "Educative.io",
     "category": "Learning",
     "offer_type": "free",
-    "description": "Free 3 months of backend development curriculum (Python, Go, TypeScript).",
-    "link": "https://www.boot.dev/pricing",
+    "description": "6 months free via GitHub Student Pack. 70+ interactive courses on programming, system design, and interviews.",
+    "link": "https://www.educative.io/github-students",
     "tags": [
-      "GitHub Student Pack",
-      "Backend",
-      "Courses"
+      "Courses",
+      "Interview Prep",
+      "GitHub"
+    ],
+    "popularity": 8
+  },
+  {
+    "id": "evernote-student",
+    "name": "Evernote Student",
+    "category": "Productivity",
+    "offer_type": "discount",
+    "description": "40% off Evernote Professional via UNiDAYS verification. Note-taking with AI search, PDF annotation, and sync.",
+    "link": "https://evernote.com/unidays",
+    "tags": [
+      "Notes",
+      "Organization",
+      "Productivity"
+    ],
+    "popularity": 6
+  },
+  {
+    "id": "figma",
+    "name": "Figma Education",
+    "category": "Design",
+    "offer_type": "free",
+    "description": "Free Figma Professional for 2 years. Unlimited files, version history, and team libraries. Verify with school email.",
+    "link": "https://www.figma.com/education/",
+    "tags": [
+      "Design",
+      "UI/UX",
+      "Collaboration"
+    ],
+    "popularity": 10
+  },
+  {
+    "id": "framer",
+    "name": "Framer",
+    "category": "Design",
+    "offer_type": "free",
+    "description": "Free Basic plan for 1 year (worth $120/year), renewable every 11 months while enrolled.",
+    "link": "https://www.framer.com/education/students/",
+    "tags": [
+      "Design",
+      "Web Design",
+      "No-Code"
     ],
     "popularity": 5
   },
@@ -747,44 +441,187 @@
     "popularity": 5
   },
   {
-    "id": "new-relic",
-    "name": "New Relic",
+    "id": "github-copilot",
+    "name": "GitHub Copilot Pro",
+    "category": "AI Tools",
+    "offer_type": "free",
+    "description": "Free Copilot Pro while you're a student. AI pair programmer with unlimited completions and chat.",
+    "link": "https://github.com/education/students",
+    "tags": [
+      "AI",
+      "Coding",
+      "GitHub"
+    ],
+    "popularity": 10
+  },
+  {
+    "id": "github-student-pack",
+    "name": "GitHub Student Developer Pack",
     "category": "Dev Tools",
     "offer_type": "free",
-    "description": "Free observability platform while enrolled (500 GB/month, 3 users, worth $300/month).",
-    "link": "https://newrelic.com/students",
+    "description": "100+ free tools including Copilot Pro, JetBrains IDEs, DigitalOcean credits, domains, and more.",
+    "link": "https://education.github.com/pack",
     "tags": [
-      "Monitoring",
-      "Observability",
-      "GitHub Student Pack"
+      "Free Tools",
+      "Dev Pack",
+      "Essential"
+    ],
+    "popularity": 10
+  },
+  {
+    "id": "gitkraken",
+    "name": "GitKraken",
+    "category": "Dev Tools",
+    "offer_type": "trial",
+    "description": "6 months free via GitHub Student Pack, then 80% off while a student. Git GUI client with GitLens VS Code extension.",
+    "link": "https://www.gitkraken.com/github-student-developer-pack-bundle",
+    "tags": [
+      "Git",
+      "GitHub",
+      "Dev Tools"
+    ],
+    "popularity": 7
+  },
+  {
+    "id": "google-cloud",
+    "name": "Google Cloud Credits",
+    "category": "Cloud & Hosting",
+    "offer_type": "credits",
+    "description": "$300 free credits for students plus always-free tier. Access through Google for Education or the standard free trial.",
+    "link": "https://cloud.google.com/edu/students",
+    "tags": [
+      "Cloud",
+      "Google",
+      "GCP"
+    ],
+    "popularity": 9
+  },
+  {
+    "id": "google-gemini-pro",
+    "name": "Google Gemini Pro",
+    "category": "AI Tools",
+    "offer_type": "free",
+    "description": "Free 12-month Google AI Pro for students. Includes Gemini 2.5 Pro, Deep Research, and NotebookLM Plus.",
+    "link": "https://gemini.google/students/",
+    "tags": [
+      "AI",
+      "Google",
+      "Research"
+    ],
+    "popularity": 10
+  },
+  {
+    "id": "gorails",
+    "name": "GoRails",
+    "category": "Learning",
+    "offer_type": "free",
+    "description": "12 months free via GitHub Student Pack. 300+ Ruby on Rails video tutorials covering full-stack development.",
+    "link": "https://gorails.com/github-students",
+    "tags": [
+      "GitHub Student Pack",
+      "Ruby on Rails",
+      "Web Development",
+      "Courses"
     ],
     "popularity": 5
   },
   {
-    "id": "framer",
-    "name": "Framer",
+    "id": "grammarly",
+    "name": "Grammarly",
+    "category": "Productivity",
+    "offer_type": "discount",
+    "description": "Student discounts available via SheerID/UNiDAYS verification. Free Premium tier plus AI features for students.",
+    "link": "https://www.grammarly.com/students",
+    "tags": [
+      "Writing",
+      "AI",
+      "Grammar"
+    ],
+    "popularity": 8
+  },
+  {
+    "id": "hack-the-box",
+    "name": "Hack The Box Student",
+    "category": "Learning",
+    "offer_type": "discount",
+    "description": "10-20% off student subscription for cybersecurity training. Hands-on labs, challenges, and career-focused content.",
+    "link": "https://academy.hackthebox.com/billing",
+    "tags": [
+      "Cybersecurity",
+      "Hacking",
+      "Labs"
+    ],
+    "popularity": 7
+  },
+  {
+    "id": "heroku",
+    "name": "Heroku",
+    "category": "Cloud & Hosting",
+    "offer_type": "credits",
+    "description": "$13/month platform credit for 24 months via GitHub Student Pack. Easy app deployment with managed infrastructure.",
+    "link": "https://www.heroku.com/github-students",
+    "tags": [
+      "PaaS",
+      "Hosting",
+      "GitHub"
+    ],
+    "popularity": 6
+  },
+  {
+    "id": "ibm-skillsbuild",
+    "name": "IBM SkillsBuild",
+    "category": "Learning",
+    "offer_type": "free",
+    "description": "Free 1000+ courses in AI, cybersecurity, cloud, and data science. Earn industry-recognized credentials.",
+    "link": "https://skillsbuild.org/students",
+    "tags": [
+      "Courses",
+      "Certifications",
+      "IBM"
+    ],
+    "popularity": 8
+  },
+  {
+    "id": "icons8",
+    "name": "Icons8",
+    "category": "Design",
+    "offer_type": "trial",
+    "description": "Free 3-month subscription to icons, illustrations, music, and stock photos.",
+    "link": "https://icons8.com/github-students",
+    "tags": [
+      "GitHub Student Pack",
+      "Design Assets",
+      "Icons",
+      "Graphics"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "jetbrains-ides",
+    "name": "JetBrains IDEs",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free access to all JetBrains professional IDEs (IntelliJ, PyCharm, WebStorm, etc.). Renewable annually.",
+    "link": "https://www.jetbrains.com/community/education/#students",
+    "tags": [
+      "IDE",
+      "Programming",
+      "Java"
+    ],
+    "popularity": 9,
+    "repo": "JetBrains/intellij-community"
+  },
+  {
+    "id": "jitter",
+    "name": "Jitter for Education",
     "category": "Design",
     "offer_type": "free",
-    "description": "Free Basic plan for 1 year (worth $120/year), renewable every 11 months while enrolled.",
-    "link": "https://www.framer.com/education/students/",
+    "description": "Free advanced export features: GIF, Video, ProRes, WebM, Lottie, 4K/120fps quality, no watermark.",
+    "link": "https://jitter.video/pricing",
     "tags": [
-      "Design",
-      "Web Design",
-      "No-Code"
-    ],
-    "popularity": 5
-  },
-  {
-    "id": "browserstack",
-    "name": "BrowserStack",
-    "category": "Dev Tools",
-    "offer_type": "free",
-    "description": "Free 1-year Live and Automate Mobile plan (worth $2,388). Test on 3,000+ real browsers and devices.",
-    "link": "https://www.browserstack.com/github-students",
-    "tags": [
-      "Testing",
-      "Browsers",
-      "GitHub Student Pack"
+      "Video",
+      "Animation",
+      "Motion Design"
     ],
     "popularity": 5
   },
@@ -803,77 +640,32 @@
     "popularity": 5
   },
   {
-    "id": "icons8",
-    "name": "Icons8",
-    "category": "Design",
-    "offer_type": "trial",
-    "description": "Free 3-month subscription to icons, illustrations, music, and stock photos.",
-    "link": "https://icons8.com/github-students",
-    "tags": [
-      "GitHub Student Pack",
-      "Design Assets",
-      "Icons",
-      "Graphics"
-    ],
-    "popularity": 5
-  },
-  {
-    "id": "codedex",
-    "name": "Codédex",
-    "category": "Learning",
-    "offer_type": "free",
-    "description": "Free 6-month Codédex Club premium with interactive Python, JavaScript, HTML/CSS, and Git courses.",
-    "link": "https://www.codedex.io/github-students",
-    "tags": [
-      "GitHub Student Pack",
-      "Coding",
-      "Courses"
-    ],
-    "popularity": 5
-  },
-  {
-    "id": "polypane",
-    "name": "Polypane",
+    "id": "localstack",
+    "name": "LocalStack",
     "category": "Dev Tools",
     "offer_type": "free",
-    "description": "Free for 1 year for non-commercial work via GitHub Student Pack. Dev browser with responsive testing.",
-    "link": "https://polypane.app/github-students/",
+    "description": "Free AWS emulator with all services, 1,000 monthly CI/CD credits via GitHub Student Pack.",
+    "link": "https://www.localstack.cloud/localstack-for-students",
     "tags": [
-      "Browser",
-      "GitHub Student Pack",
-      "Web Development",
-      "Accessibility"
-    ],
-    "popularity": 5
-  },
-  {
-    "id": "gorails",
-    "name": "GoRails",
-    "category": "Learning",
-    "offer_type": "free",
-    "description": "12 months free via GitHub Student Pack. 300+ Ruby on Rails video tutorials covering full-stack development.",
-    "link": "https://gorails.com/github-students",
-    "tags": [
-      "GitHub Student Pack",
-      "Ruby on Rails",
-      "Web Development",
-      "Courses"
-    ],
-    "popularity": 5
-  },
-  {
-    "id": "dashlane",
-    "name": "Dashlane",
-    "category": "Security",
-    "offer_type": "free",
-    "description": "Free Premium for 1 year with student email. Password manager with auto-login and dark web monitoring.",
-    "link": "https://www.dashlane.com/students",
-    "tags": [
-      "Passwords",
-      "Security",
+      "AWS",
+      "Cloud",
       "GitHub Student Pack"
     ],
     "popularity": 5
+  },
+  {
+    "id": "loom-education",
+    "name": "Loom Education",
+    "category": "Productivity",
+    "offer_type": "discount",
+    "description": "50-75% off Loom for verified students and educators. Unlimited recordings, HD quality, and full editing tools.",
+    "link": "https://www.loom.com/use-case/education",
+    "tags": [
+      "Video",
+      "Recording",
+      "Communication"
+    ],
+    "popularity": 7
   },
   {
     "id": "lumix-edu",
@@ -890,90 +682,61 @@
     "popularity": 5
   },
   {
-    "id": "jitter",
-    "name": "Jitter for Education",
-    "category": "Design",
+    "id": "microsoft-365",
+    "name": "Microsoft 365 Education",
+    "category": "Productivity",
     "offer_type": "free",
-    "description": "Free advanced export features: GIF, Video, ProRes, WebM, Lottie, 4K/120fps quality, no watermark.",
-    "link": "https://jitter.video/pricing",
+    "description": "Free Word, Excel, PowerPoint, OneNote, Teams, and 1TB OneDrive storage with valid school email address.",
+    "link": "https://www.microsoft.com/en-us/education/products/office",
     "tags": [
-      "Video",
-      "Animation",
-      "Motion Design"
-    ],
-    "popularity": 5
-  },
-  {
-    "id": "datadog",
-    "name": "Datadog",
-    "category": "Dev Tools",
-    "offer_type": "free",
-    "description": "Free Pro for 2 years. Monitor 10 hosts, 500 GB logs, 1,000 browser tests, 15-month data retention.",
-    "link": "https://studentpack.datadoghq.com/signup",
-    "tags": [
-      "Monitoring",
-      "Observability",
-      "GitHub Student Pack"
-    ],
-    "popularity": 5
-  },
-  {
-    "id": "codecov",
-    "name": "Codecov",
-    "category": "Dev Tools",
-    "offer_type": "free",
-    "description": "Free code coverage forever on public and private repositories. Included in GitHub Student Pack.",
-    "link": "https://about.codecov.io/solution/students",
-    "tags": [
-      "Code Coverage",
-      "Testing",
-      "CI/CD",
-      "GitHub Student Pack"
-    ],
-    "popularity": 5
-  },
-  {
-    "id": "sentry",
-    "name": "Sentry",
-    "category": "Dev Tools",
-    "offer_type": "free",
-    "description": "Free 1-year education plan with 50K errors/month, unlimited team members, and AI debugging.",
-    "link": "https://sentry.io/for/education",
-    "tags": [
-      "Error Tracking",
-      "Monitoring",
-      "GitHub Student Pack"
-    ],
-    "popularity": 5
-  },
-  {
-    "id": "bootstrap-studio",
-    "name": "Bootstrap Studio",
-    "category": "Design",
-    "offer_type": "free",
-    "description": "Free desktop app license for building responsive Bootstrap websites while enrolled.",
-    "link": "https://bootstrapstudio.io/students",
-    "tags": [
-      "Web Design",
-      "Bootstrap",
-      "GitHub Student Pack"
-    ],
-    "popularity": 5
-  },
-  {
-    "id": "adobe-creative-cloud",
-    "name": "Adobe Creative Cloud",
-    "category": "Design",
-    "offer_type": "discount",
-    "description": "60%+ off 20+ apps including Photoshop, Illustrator, and Premiere. $19.99/month for the first year.",
-    "link": "https://www.adobe.com/creativecloud/buy/students.html",
-    "tags": [
-      "Design",
-      "Photography",
-      "Video",
-      "Creative"
+      "Office",
+      "Documents",
+      "Microsoft"
     ],
     "popularity": 9
+  },
+  {
+    "id": "microsoft-azure",
+    "name": "Microsoft Azure",
+    "category": "Cloud & Hosting",
+    "offer_type": "credits",
+    "description": "$100 free credits yearly (renewable while enrolled), no credit card required. 55+ Azure services.",
+    "link": "https://azure.microsoft.com/en-us/free/students",
+    "tags": [
+      "Azure",
+      "Microsoft",
+      "Cloud"
+    ],
+    "popularity": 9
+  },
+  {
+    "id": "miro-education",
+    "name": "Miro Education",
+    "category": "Productivity",
+    "offer_type": "free",
+    "description": "Free for 2 years. Unlimited boards, high-res exports, and custom templates. Apply with student documentation.",
+    "link": "https://miro.com/education-whiteboard/",
+    "tags": [
+      "Whiteboard",
+      "Collaboration",
+      "Planning"
+    ],
+    "popularity": 8
+  },
+  {
+    "id": "mongodb-atlas",
+    "name": "MongoDB Atlas",
+    "category": "Cloud & Hosting",
+    "offer_type": "credits",
+    "description": "$50 in credits plus free MongoDB University access via GitHub Student Pack. Cloud database with generous free tier.",
+    "link": "https://www.mongodb.com/students",
+    "tags": [
+      "Database",
+      "NoSQL",
+      "Cloud"
+    ],
+    "popularity": 7,
+    "repo": "mongodb/mongo"
   },
   {
     "id": "namecheap",
@@ -990,59 +753,102 @@
     "popularity": 5
   },
   {
-    "id": "tower",
-    "name": "Tower",
+    "id": "new-relic",
+    "name": "New Relic",
     "category": "Dev Tools",
     "offer_type": "free",
-    "description": "Free Tower Pro Git client for 12 months, renewable annually while enrolled. No credit card required.",
-    "link": "https://www.git-tower.com/students",
+    "description": "Free observability platform while enrolled (500 GB/month, 3 users, worth $300/month).",
+    "link": "https://newrelic.com/students",
     "tags": [
-      "Git",
-      "GitHub Student Pack",
-      "Dev Tools"
+      "Monitoring",
+      "Observability",
+      "GitHub Student Pack"
     ],
     "popularity": 5
   },
   {
-    "id": "arduino-cloud",
-    "name": "Arduino Cloud",
-    "category": "Dev Tools",
-    "offer_type": "trial",
-    "description": "Free 6-month Arduino Cloud Maker Plan plus hardware discounts (25–50% off select boards) via GitHub Student Pack.",
-    "link": "https://www.arduino.cc/github/students",
+    "id": "notion",
+    "name": "Notion Education",
+    "category": "Productivity",
+    "offer_type": "free",
+    "description": "Free Plus plan with unlimited blocks, file uploads, and 30-day version history. Just sign in with your .edu email.",
+    "link": "https://www.notion.so/product/notion-for-education",
     "tags": [
-      "IoT",
-      "Hardware",
+      "Notes",
+      "Planning",
+      "Knowledge"
+    ],
+    "popularity": 10
+  },
+  {
+    "id": "nvidia-education",
+    "name": "NVIDIA Education",
+    "category": "Learning",
+    "offer_type": "discount",
+    "description": "Academic GPU discounts, free DLI courses, and research grants. Reduced prices on Jetson developer kits.",
+    "link": "https://developer.nvidia.com/higher-education-and-research",
+    "tags": [
+      "GPU",
+      "AI",
+      "Hardware"
+    ],
+    "popularity": 7
+  },
+  {
+    "id": "obsidian",
+    "name": "Obsidian",
+    "category": "Productivity",
+    "offer_type": "discount",
+    "description": "App is free for everyone. Students get 40% off Sync ($29/year) and Publish for cloud backup and publishing.",
+    "link": "https://obsidian.md/pricing",
+    "tags": [
+      "Notes",
+      "Markdown",
+      "PKM"
+    ],
+    "popularity": 9,
+    "repo": "obsidianmd/obsidian-releases"
+  },
+  {
+    "id": "oracle-cloud",
+    "name": "Oracle Cloud",
+    "category": "Cloud & Hosting",
+    "offer_type": "credits",
+    "description": "$300 free credits plus always-free tier via Oracle Academy. Includes Autonomous Database, VMs, and storage.",
+    "link": "https://academy.oracle.com/en/solutions-cloud-program.html",
+    "tags": [
       "Cloud",
-      "GitHub Student Pack"
+      "Database",
+      "Enterprise"
     ],
-    "popularity": 5
+    "popularity": 6
   },
   {
-    "id": "clerk",
-    "name": "Clerk",
-    "category": "Dev Tools",
-    "offer_type": "free",
-    "description": "Free Pro plan until graduation ($240/yr value) — 50K MAUs, MFA, SSO, and Organizations.",
-    "link": "https://clerk.com/github-student-developer-pack",
+    "id": "perplexity-pro",
+    "name": "Perplexity Pro",
+    "category": "AI Tools",
+    "offer_type": "discount",
+    "description": "50% off Pro for students with .edu email. Includes Study Mode, unlimited uploads, and Research Mode.",
+    "link": "https://www.perplexity.ai/students",
     "tags": [
-      "Authentication",
-      "Identity",
-      "GitHub Student Pack"
+      "AI",
+      "Search",
+      "Research"
     ],
-    "popularity": 5
+    "popularity": 8
   },
   {
-    "id": "adafruit",
-    "name": "Adafruit",
+    "id": "polypane",
+    "name": "Polypane",
     "category": "Dev Tools",
     "offer_type": "free",
-    "description": "Free 1-year Adafruit IO+ membership and 30% off select Circuit Playground hardware.",
-    "link": "https://www.adafruit.com/github-students",
+    "description": "Free for 1 year for non-commercial work via GitHub Student Pack. Dev browser with responsive testing.",
+    "link": "https://polypane.app/github-students/",
     "tags": [
-      "Hardware",
-      "IoT",
-      "GitHub Student Pack"
+      "Browser",
+      "GitHub Student Pack",
+      "Web Development",
+      "Accessibility"
     ],
     "popularity": 5
   },
@@ -1062,6 +868,104 @@
     "popularity": 5
   },
   {
+    "id": "postman-student",
+    "name": "Postman Student Expert",
+    "category": "Learning",
+    "offer_type": "free",
+    "description": "Free API training and certification. Learn API fundamentals, earn a digital badge, and join the community.",
+    "link": "https://academy.postman.com/page/students",
+    "tags": [
+      "API",
+      "Certification",
+      "Dev Tools"
+    ],
+    "popularity": 8
+  },
+  {
+    "id": "raycast-pro",
+    "name": "Raycast Pro",
+    "category": "Productivity",
+    "offer_type": "discount",
+    "description": "50% student discount ($5/month). Mac productivity launcher with AI, cloud sync, and custom themes.",
+    "link": "https://www.raycast.com/pricing",
+    "tags": [
+      "Mac",
+      "Productivity",
+      "AI"
+    ],
+    "popularity": 7
+  },
+  {
+    "id": "red-hat-developer",
+    "name": "Red Hat Developer",
+    "category": "Cloud & Hosting",
+    "offer_type": "free",
+    "description": "Free RHEL subscription for up to 16 systems. Full access to updates and self-service support. Renewable annually.",
+    "link": "https://developers.redhat.com/register",
+    "tags": [
+      "Linux",
+      "Enterprise",
+      "DevOps"
+    ],
+    "popularity": 6
+  },
+  {
+    "id": "samsung-education",
+    "name": "Samsung Education",
+    "category": "Lifestyle",
+    "offer_type": "discount",
+    "description": "Up to 30% off Galaxy phones, tablets, laptops, and accessories. Verify with .edu email or ID.me.",
+    "link": "https://www.samsung.com/us/shop/offer-program/education/",
+    "tags": [
+      "Hardware",
+      "Phones",
+      "Laptops"
+    ],
+    "popularity": 8
+  },
+  {
+    "id": "sentry",
+    "name": "Sentry",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free 1-year education plan with 50K errors/month, unlimited team members, and AI debugging.",
+    "link": "https://sentry.io/for/education",
+    "tags": [
+      "Error Tracking",
+      "Monitoring",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "sketch",
+    "name": "Sketch",
+    "category": "Design",
+    "offer_type": "free",
+    "description": "Free for 1 year. Professional UI/UX design tool for Mac with prototyping, collaboration, and plugins.",
+    "link": "https://www.sketch.com/education/",
+    "tags": [
+      "Design",
+      "UI/UX",
+      "Mac"
+    ],
+    "popularity": 7
+  },
+  {
+    "id": "spotify-student",
+    "name": "Spotify Premium Student",
+    "category": "Lifestyle",
+    "offer_type": "discount",
+    "description": "$6.99/month (50% off) with Hulu included. Ad-free music, offline downloads, unlimited skips. Valid for up to 4 years.",
+    "link": "https://www.spotify.com/us/student/",
+    "tags": [
+      "Music",
+      "Streaming",
+      "Hulu"
+    ],
+    "popularity": 10
+  },
+  {
     "id": "stripe",
     "name": "Stripe",
     "category": "Dev Tools",
@@ -1072,6 +976,47 @@
       "Payments",
       "Dev Tools",
       "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "student-beans",
+    "name": "Student Beans",
+    "category": "Lifestyle",
+    "offer_type": "discount",
+    "description": "Free platform with 10,000+ student discounts on fashion, tech, food, and travel. Digital student ID included.",
+    "link": "https://www.studentbeans.com/us",
+    "tags": [
+      "Discounts",
+      "Shopping"
+    ],
+    "popularity": 8
+  },
+  {
+    "id": "termius-pro",
+    "name": "Termius Pro",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free Pro and Team features via GitHub Student Pack. SSH client with sync, SFTP, and team sharing.",
+    "link": "https://termius.com/education",
+    "tags": [
+      "SSH",
+      "Terminal",
+      "GitHub"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "tower",
+    "name": "Tower",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free Tower Pro Git client for 12 months, renewable annually while enrolled. No credit card required.",
+    "link": "https://www.git-tower.com/students",
+    "tags": [
+      "Git",
+      "GitHub Student Pack",
+      "Dev Tools"
     ],
     "popularity": 5
   },
@@ -1088,5 +1033,60 @@
       "GitHub Student Pack"
     ],
     "popularity": 5
+  },
+  {
+    "id": "tryhackme",
+    "name": "TryHackMe Student",
+    "category": "Learning",
+    "offer_type": "discount",
+    "description": "20% off annual subscription. Beginner-friendly cybersecurity training with guided learning paths and virtual labs.",
+    "link": "https://tryhackme.com/discounts",
+    "tags": [
+      "Cybersecurity",
+      "Learning",
+      "Labs"
+    ],
+    "popularity": 7
+  },
+  {
+    "id": "unidays",
+    "name": "UNiDAYS",
+    "category": "Lifestyle",
+    "offer_type": "discount",
+    "description": "Free access to hundreds of verified student discounts on fashion, tech, food, travel, and entertainment.",
+    "link": "https://www.myunidays.com/US/en-US/account/register",
+    "tags": [
+      "Discounts",
+      "Shopping"
+    ],
+    "popularity": 8
+  },
+  {
+    "id": "unity-student",
+    "name": "Unity Student",
+    "category": "Design",
+    "offer_type": "free",
+    "description": "Free Unity Pro features for students. Includes Odin Inspector license and 20% off assets. Renewable.",
+    "link": "https://unity.com/products/unity-student",
+    "tags": [
+      "Game Dev",
+      "3D",
+      "Engine"
+    ],
+    "popularity": 8
+  },
+  {
+    "id": "youtube-premium-student",
+    "name": "YouTube Premium Student",
+    "category": "Lifestyle",
+    "offer_type": "discount",
+    "description": "$7.99/month (50% off). Ad-free videos, offline downloads, YouTube Music included. Valid up to 4 years.",
+    "link": "https://www.youtube.com/premium/student",
+    "tags": [
+      "Video",
+      "Streaming",
+      "Music"
+    ],
+    "popularity": 9
   }
 ]

--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -95,6 +95,10 @@ def validate_benefits() -> None:
         if isinstance(b.get("link"), str):
             check_link(name, b["link"])
 
+    ids = [b.get("id", "") for b in data if b.get("id")]
+    if ids != sorted(ids):
+        err("benefits.json: entries must be sorted by id (ascending) — insert new entries in sorted position, do not append to the end")
+
 
 def validate_events() -> None:
     data = load("events.json")


### PR DESCRIPTION
## Summary

Root-cause fix for the conflict cascade that hit the add-benefit PR backlog twice. Every add-benefit PR **appended** its entry to the same `benefits.json` array tail, so merging any one PR conflicted all the others — forcing manual re-resolution per merge.

**Fix: keep `benefits.json` sorted by `id`, insert in place.** A burst of unrelated products (adobe, namecheap, tower, stripe…) then lands in *different* regions of the file, so git **auto-merges** them. Only near-adjacent ids could ever collide.

## Changes
- **`data/benefits.json`** — one-time sort by `id` (77 entries, identical set, large diff is pure reordering).
- **`scripts/validate_data.py`** — new CI gate: entries must be ascending by `id`. Negative-tested (a scrambled file is correctly rejected).
- **`.github/workflows/add-benefit.yml`** — Grant now inserts in sorted position instead of appending.
- **`CLAUDE.md`** — documents the invariant + rationale (mirrors the existing events "sorted by date" rule).

## Safety
- Display order **unaffected** — `benefits/index.js` sorts client-side by popularity; file order doesn't drive the UI.
- Validator green on the sorted file; rejects out-of-order. Same 77-entry set before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)