### PR TITLE
Ground link selection: agents write only URLs they actually loaded

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -87,9 +87,19 @@ jobs:
             - `tags`: 2–4 relevant tags. If body contains `**Pack**: GitHub Student Pack`, include `"GitHub Student Pack"`
             - Add `"repo": "owner/repo"` if open source
 
-            Prefer the user-provided link; otherwise find the official student signup URL.
+            Start from the user-provided link if present; otherwise find the official student signup URL. Either way, the link is a candidate to verify in Step 4.5 — not a value to trust as-is.
 
             `link` MUST be the program's own signup, pricing, or program-overview page (e.g. `/students`, `/education`, `/edu`, `/pricing`). Never use a help/docs/support article URL — subdomains `help.`/`support.`/`docs.` or paths containing `/articles/`. Those are documentation, not signup destinations. If only a help-article URL is available, WebSearch the underlying program page and use that instead.
+
+            ## Step 4.5: Verify the link actually loads (required — do not skip)
+
+            The `link` you write MUST be a URL you loaded successfully **in this run**. Never construct or guess a path from the product name (e.g. inventing `/github-students` because it looks plausible) — that is how dead links reach the directory.
+
+            1. `WebFetch` your chosen `link`. A real page must load — not a 404, "page not found", or error page. Treat a redirect's final URL as the real link and use that.
+            2. If it does not load: `WebSearch` for the program's actual student signup/education page, `WebFetch` the top candidate, and use the URL that genuinely loads. Copy it **verbatim** — do not edit the path by hand.
+            3. If no working student-program URL loads after this, the program isn't addable: comment "**Cannot add:** could not confirm a live student signup page", append to `rejected.json` (Step 3 format), close the issue, and stop.
+
+            This applies even when the user supplied the link — a submitted URL is a candidate, not a verified one.
 
             ## Step 5: Write files
 

--- a/.github/workflows/discover-benefits.yml
+++ b/.github/workflows/discover-benefits.yml
@@ -87,6 +87,8 @@ jobs:
 
             Shortlist up to **5 new benefits** across both passes.
 
+            The `**Signup**` URL you record in Step 5 MUST be a URL you actually loaded with WebFetch in this run (the program page from this step, or a real signup link found on it). Never construct or guess a path from the product name — an invented `/github-students`-style URL that 404s poisons the downstream add-benefit PR, which trusts the link you provide. Copy the working URL verbatim; if a redirect occurred, record the final URL.
+
             ## Step 5: Open issues
 
             For each, create one GitHub issue:
@@ -94,7 +96,7 @@ jobs:
             - **Body**:
               ```
               **What students get**: <one specific sentence — plan, amount, or duration>
-              **Signup**: <direct URL>
+              **Signup**: <direct URL — must be one you loaded successfully in Step 4, copied verbatim>
               **Discovered via**: <known-source | keyword>
               **Pack**: GitHub Student Pack
               ```

--- a/agent/index.html
+++ b/agent/index.html
@@ -123,7 +123,7 @@
         </div>
         <div id="panel-web" class="node-panel" hidden>
           <p class="node-panel-title">Web Fetch</p>
-          <p>Claude Code’s built-in <code>WebFetch</code> tool. After Web Search returns candidate URLs, Grant fetches the actual pages to confirm the program is real, active, and has a direct student signup link. Read-only. No forms submitted, no side effects.</p>
+          <p>Claude Code’s built-in <code>WebFetch</code> tool. After Web Search returns candidate URLs, Grant fetches the actual pages to confirm the program is real, active, and has a direct student signup link. The link Grant records must be one it loaded successfully in the same run — never a path guessed from the product name — so dead URLs don’t reach a PR. Read-only. No forms submitted, no side effects.</p>
         </div>
         <div id="panel-output" class="node-panel" hidden>
           <p class="node-panel-title">GitHub Output</p>


### PR DESCRIPTION
## Summary

Fixes the class of bug behind #247 (Simple Analytics shipped `simpleanalytics.com/github-students`, a 404 — the live signup is `dashboard.simpleanalytics.com/students`).

**Root cause:** `discover-benefits` wrote a signup path *constructed from the product name*, never loaded it, and `add-benefit` then trusted the submitted link as-is (its prompt said "prefer the user-provided link"). Two compounding instances of the same failure — regenerating a URL instead of retrieving one. The CI validator can't catch this by design: it's a deterministic offline shape gate (`validate_data.py` never fetches), and `/github-students` is well-formed.

**Fix — verify the link in-run, at the point each agent writes it:**

- **`discover-benefits`**: the recorded `**Signup**` URL must be one loaded via `WebFetch` this run, copied verbatim — never a guessed path.
- **`add-benefit`**: new **Step 4.5** fetches the chosen link and requires a real page (2xx) before writing — *even when the user supplied it*. Non-loading → search for the real signup page or reject.
- **`agent/index.html`**: WebFetch panel now states links are run-verified (keeps the agent page in sync).

**Why in-run self-verify (not a CI network gate):** keeps CI deterministic/offline — no flaky required check from headless-runner 403s. Weekly `maintain-benefits` + the human merge remain the post-merge liveness backstops.

PR #247's link is fixed separately on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)