### PR TITLE
Document authorship convention (agent authors, maintainer approves)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,7 @@ gh workflow run maintain-benefits.yml --repo student-benefits/student-benefits.g
 - GitHub Pages serves the site directly from the `main` branch root
 - Every PR automatically requests review from the maintainer (via CODEOWNERS)
 - Branch protection requires maintainer approval (CODEOWNERS) before any PR can merge
+- **Authorship: the agent authors, the maintainer approves and merges** — the merge is the trust boundary. A PR's GitHub author is fixed by the token that opens it: workflow-opened PRs are authored by the Claude GitHub App (`app/claude`), the intended state. A PR opened from a locally maintainer-authenticated `gh` is authored by the maintainer instead — so to keep the agent as author, push commits onto an existing `app/claude` branch (e.g. when consolidating) rather than opening a fresh PR, and author commits as `Claude <noreply@anthropic.com>`. Never self-approve or self-merge.
 
 ---
 


### PR DESCRIPTION
## Summary

Persists the authorship rule used while consolidating the open PRs into the Git workflow section of `CLAUDE.md`:

- The **agent authors** changes — commits as `Claude <noreply@anthropic.com>`, PRs opened by the `app/claude` GitHub App (or by pushing onto an existing `app/claude` branch when consolidating, so the PR stays Claude-authored).
- The **maintainer approves and merges** — the merge remains the trust boundary; no self-merge.

Documents *why* the GitHub PR "author" depends on the token that opens it, so future sessions don't accidentally open maintainer-authored PRs.

> Note: this PR is itself an example of the local-token limitation — it's opened by the maintainer's `gh`, so GitHub shows it authored by the maintainer, not `app/claude`. The commit inside is Claude-authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)