### PR TITLE
Ground event links: agents write only URLs they actually loaded

### DIFF
--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -69,6 +69,16 @@ jobs:
 
             See the data/events.json schema in CLAUDE.md. Categories: `hackathon | conference | fellowship | summit | workshop | grant`. Write `why` yourself (max 200 chars, don't copy marketing). `expires` = `date_end` (or `date` if single-day). Omit `date_end` if single-day; omit `location` if fully remote.
 
+            ## Step 5.5: Verify the link actually loads (required — do not skip)
+
+            The `link` you write MUST be a URL you loaded successfully **in this run**. Never construct or guess a path from the event name — a plausible-looking but dead URL is the failure to prevent.
+
+            1. `WebFetch` your chosen `link`. A real application/registration page must load — not a 404, "page not found", or error page. Treat a redirect's final URL as the real link and use that.
+            2. If it does not load: `WebSearch` for the event's actual registration/application page, `WebFetch` the top candidate, and use the URL that genuinely loads. Copy it **verbatim** — do not edit the path by hand.
+            3. If no working event URL loads, you can't confirm it: comment "**Cannot add:** could not confirm a live registration page", close the issue, and stop.
+
+            This applies even when the user supplied the link — a submitted URL is a candidate, not a verified one.
+
             ## Step 6: Update files
 
             Insert the new event into `data/events.json` in date order (earliest first), preserving 2-space indent and trailing newline.

--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -86,6 +86,8 @@ jobs:
 
             See the data/events.json schema in CLAUDE.md. Write `why` yourself (max 200 chars, no marketing). `expires` = `date_end` (or `date` if single-day). Omit `date_end` if single-day; omit `location` if fully remote.
 
+            The `link` for each entry MUST be a URL you actually loaded with WebFetch in Step 5 (the event page, or a real registration link found on it). Never construct or guess a path from the event name — a plausible-looking but dead URL poisons the PR. Copy the working URL verbatim; if a redirect occurred, record the final URL. Drop any entry whose link you can't confirm loads.
+
             ## Step 7: Open one PR
 
             Updated `data/events.json`: remove expired IDs from Step 2, append new entries from Step 6 (in date order earliest first), preserve 2-space indent + trailing newline.


### PR DESCRIPTION
## Summary

Extends the #253 link-liveness fix (benefits side) to the **event** side — the two workflows that write event URLs and could ship a plausible-but-dead path guessed from the event name (the #247 / Simple Analytics failure mode).

- **`add-event`**: new **Step 5.5** fetches the chosen link and requires a real registration page (2xx) before writing — *even when the user supplied it*. Non-loading → search for the real page or reject.
- **`discover-events`**: each entry's link must be one loaded via `WebFetch` in the verify step, copied verbatim; drop any entry whose link can't be confirmed.

In-run self-verify, consistent with the benefit side. CI stays deterministic/offline (no flaky network gate); the agent page's WebFetch panel already documents run-verified links and covers events.

> Per the authorship convention (#254): commit is Claude-authored; this PR shows "opened by" the maintainer because it's opened from a local token, not the `app/claude` bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)