### PR TITLE
Encode build/grow curation criterion across the pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-benefit.yml
+++ b/.github/ISSUE_TEMPLATE/new-benefit.yml
@@ -8,6 +8,8 @@ body:
       value: |
         **Name the benefit — a few words is enough.** Grant finds the signup URL and extracts the details.
 
+        This directory is for benefits that help students **build, learn, and ship** — dev tools, cloud/AI credits, design and learning resources. Consumption perks (music, video streaming, shopping, broad discount aggregators) are out of scope, however good the deal.
+
   - type: textarea
     id: description
     attributes:
@@ -19,7 +21,7 @@ body:
         "Notion is free for students"
         "JetBrains gives free IDEs"
         "check out figma education"
-        "Spotify has 50% off for students - includes Hulu"
+        "GitHub Copilot is free for verified students"
 
         Or be more detailed if you prefer:
         "Cursor offers one free year of Cursor Pro for verified university students. It's an AI-powered code editor with 500 fast requests per month. Sign up at cursor.com/students"

--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -60,6 +60,8 @@ jobs:
 
             Use WebSearch ("{product} student discount" or "{product} education program") and WebFetch on the top result to confirm a real student program exists. Don't rely solely on training data.
 
+            **Build & grow (the curation thesis):** the benefit must help a student *create, learn, ship, or research* — dev tools, infrastructure, cloud/AI credits, design and learning platforms, the hardware students build on. Reject consumption perks regardless of how good the deal is: entertainment (music, video streaming), shopping, consumer subscriptions (e.g. a consumer VPN), and broad discount aggregators (Student Beans / UNiDAYS-style). The test isn't "is this a real student discount?" but "does this advance building or learning?" — if it doesn't, it's a reject even when the offer is genuine and well-priced.
+
             If invalid, comment "**Cannot add:** {reason}". Then append to `agent/state/rejected.json`:
             ```json
             { "name": "{name}", "domain": "{hostname or null}", "reason": "{reason}", "checked": "{YYYY-MM-DD}" }

--- a/.github/workflows/discover-benefits.yml
+++ b/.github/workflows/discover-benefits.yml
@@ -79,11 +79,12 @@ jobs:
             For each result from Steps 2 and 3: WebFetch the program page. Skip if name or hostname is in the known/rejected sets. Note source (`known-source` or `keyword`).
 
             Quality bar — reject on any failure:
-            1. Substantial offer: free tier, 50%+ discount, or meaningful credits — reject token discounts <30% with no free tier
-            2. Recognizable product with real student community
-            3. Self-serve student program page (not "contact us" / institutional purchase)
-            4. Fills a gap (avoid 4th entry in saturated categories)
-            5. Active signup page
+            1. **Build & grow** (the curation thesis): the benefit must help a student *create, learn, ship, or research* — dev tools, infrastructure, cloud/AI credits, design and learning platforms, the hardware students build on. Reject consumption perks regardless of how good the deal is: entertainment (music, video streaming), shopping, consumer subscriptions (e.g. a consumer VPN), and broad discount aggregators (Student Beans / UNiDAYS-style). If it doesn't advance building or learning, skip it.
+            2. Substantial offer: free tier, 50%+ discount, or meaningful credits — reject token discounts <30% with no free tier
+            3. Recognizable product with real student community
+            4. Self-serve student program page (not "contact us" / institutional purchase)
+            5. Fills a gap (avoid 4th entry in saturated categories)
+            6. Active signup page
 
             Shortlist up to **5 new benefits** across both passes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,15 +6,22 @@ This file is loaded automatically by Claude Code in every session.
 
 ## Project Context
 
-A community-curated directory of student discounts, free tiers, and perks. The
-site is a single static HTML/JS page (`index.html`) that reads from `data/benefits.json`
-and renders a searchable, filterable card grid. Deployed via GitHub Pages.
+A community-curated directory of student benefits that help students **build,
+learn, and ship** — dev tools, cloud credits, AI/ML platforms, design and
+learning resources. The site is a single static HTML/JS page (`index.html`) that
+reads from `data/benefits.json` and renders a searchable, filterable card grid.
+Deployed via GitHub Pages.
 
 ### Core values
 
-**Specificity.** Descriptions must say exactly what students get. Vague copy
-("Student discount available") is rejected in favor of concrete offers
-("Free Pro plan for 1 year").
+**Build & grow, not consumption.** The curation thesis — what earns an entry.
+A benefit qualifies if it helps a student *create, learn, ship, or research*:
+dev tools, infrastructure, cloud/AI credits, design and learning platforms, the
+hardware students build on. It does **not** qualify if it's a consumption perk —
+entertainment (music, video streaming), shopping, or broad discount aggregators —
+however good the deal. The test isn't "is this a real student discount?" (the
+proxy) but "does this advance building or learning?" (the criterion). A genuine,
+well-priced consumer VPN or music subscription is still a reject.
 
 **Data integrity.** All benefit data lives in `data/benefits.json` — one source of
 truth, never hardcoded in HTML.

--- a/agent/index.html
+++ b/agent/index.html
@@ -187,7 +187,7 @@
           </div>
           <div class="outcome-card rejected">
             <p class="outcome-label">✗ Rejected</p>
-            <p class="outcome-desc">No student program found after search. Issue closed, domain logged.</p>
+            <p class="outcome-desc">No student program found, or the benefit is a consumption perk rather than build &amp; grow. Issue closed, domain logged.</p>
           </div>
           <div class="outcome-card duplicate">
             <p class="outcome-label">⚠ Duplicate</p>


### PR DESCRIPTION
## Why

The directory's working criterion was "is this a real student discount?" — a *proxy*. The actual thesis is **build & grow**: surface benefits that help students create, learn, and ship. Nothing in the pipeline encoded that, so the discovery workflow surfaced a consumer VPN (#259 → #262) that passed every structural check. This makes the thesis explicit at every gate so consumption perks are rejected before they reach a PR.

## Changes

- **CLAUDE.md** — new lead Core value *"Build & grow, not consumption"* + reframed the project scope line.
- **`discover-benefits.yml`** — build/grow is now quality-bar criterion #1 (reject consumption regardless of deal quality).
- **`add-benefit.yml`** — same gate added to the validate step.
- **`new-benefit` issue template** — scope note for submitters; swapped the Spotify example for GitHub Copilot.
- **`agent/index.html`** — the *Rejected* outcome card now reflects the off-thesis rejection path (keeps the agent page in sync with behavior).

## Follow-up

The existing catalog audit (removing consumption entries, dropping the `Lifestyle` category) is a separate PR so the data changes can be reviewed line-by-line.