### PR TITLE
Align Grant with loop-engineering practice: verify loop + /agent/ redesign

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -31,7 +31,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
           allowed_bots: "claude"
-          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
           prompt: |
             You process student benefit submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it, and either open a PR adding the benefit or comment explaining why it can't be added.
 
@@ -122,6 +122,10 @@ jobs:
               "benefit": { "name": "...", "category": "...", "description": "..." }
             }
             ```
+
+            ## Step 5.5: Validate (required — this closes the loop)
+
+            Run `python3 scripts/validate_data.py`. If it exits non-zero, read the errors, fix `data/benefits.json`, and run again — repeat until it exits 0. Never open the PR while the validator is red: it is the deterministic gate for schema, link shape, and sort order, so let it catch what you missed instead of guessing.
 
             ## Step 6: Open PR + comment
 

--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -127,21 +127,24 @@ jobs:
 
             Run `python3 scripts/validate_data.py`. If it exits non-zero, read the errors, fix `data/benefits.json`, and run again — repeat until it exits 0. Never open the PR while the validator is red: it is the deterministic gate for schema, link shape, and sort order, so let it catch what you missed instead of guessing.
 
-            ## Step 6: Open PR + comment
+            ## Step 6: Add to the pending PR (or open it), then comment
 
-            Branch: `add-benefit-{id}`. Title: `{name}`. Body:
-            ```
-            ## {name}
+            New benefits accumulate on ONE rolling pull request labelled `pending-benefits`, so the maintainer reviews a single PR instead of one per submission. This is **best-effort**: if any git/PR step below fails, fall back to a standalone PR (6c) — never drop a submission, and never merge anything yourself.
 
-            **Category:** {category}
-            **Link:** {link}
+            ### 6a — Find the pending PR
+            `gh pr list --label pending-benefits --state open --json number,headRefName --limit 1`
 
-            {description}
+            ### 6b — If one exists, add to it
+            - `git fetch origin <headRefName> && git checkout <headRefName>` — it already holds earlier queued benefits; keep them all.
+            - Re-apply your Step 5 changes here: insert the entry into `data/benefits.json` in `id`-sorted position, and replace `agent/state/last-run.json`.
+            - Run `python3 scripts/validate_data.py` until it exits 0.
+            - Commit with `--author="Claude <noreply@anthropic.com>"`, then `git push`. If the push is rejected because the branch moved, run `git fetch origin <headRefName> && git reset --hard origin/<headRefName>`, redo the insertion + validation on the fresh state, and push once more. If it still fails, go to 6c.
+            - `gh pr edit <number>`: set the title to `Add {N} student benefits` (N = entries now on the branch) and append to the body one line `- {name} ({category})` and, on its own plain-text line, `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` — so merging the single PR closes every contributing issue.
 
-            ---
+            ### 6c — Otherwise (or on any 6b failure), open it
+            - `git checkout -B add-benefit-pending origin/main`. (On a 6b fallback, use branch `add-benefit-{id}` and skip the `--label` below — a standalone PR, not the rolling one.)
+            - Insert the entry, validate to green, commit, then `git push -u origin <branch>` (add `--force-with-lease` if the branch already exists from a previously-merged PR).
+            - `gh pr create --label pending-benefits --title "Add 1 student benefit: {name}"` with a body holding `- {name} ({category})` and a plain-text `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` line.
 
-            Closes #${{ github.event.issue.number || github.event.inputs.issue }}
-            ```
-            The Closes line must be plain text (not in a code fence) so GitHub auto-closes on merge.
-
-            After the PR is open, comment on the issue: "Added **{name}** ({category}) — {description}\n\nPR: {pr_url}"
+            ### 6d — Comment + close
+            Comment on the issue: "Added **{name}** ({category}) — {description}\n\nPR: {pr_url}". The merge stays a human decision.

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -31,7 +31,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
           allowed_bots: "claude"
-          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
           prompt: |
             You process student event submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it against the quality bar, and either open a PR adding the event or comment explaining why it can't be added.
 
@@ -98,6 +98,10 @@ jobs:
               "event": { "name": "...", "category": "...", "date": "...", "organizer": "..." }
             }
             ```
+
+            ## Step 6.5: Validate (required — this closes the loop)
+
+            Run `python3 scripts/validate_data.py`. If it exits non-zero, read the errors, fix `data/events.json`, and run again — repeat until it exits 0. Never open the PR while the validator is red: it is the deterministic gate for schema, link shape, and date order, so let it catch what you missed instead of guessing.
 
             ## Step 7: Open PR + comment
 

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -103,23 +103,24 @@ jobs:
 
             Run `python3 scripts/validate_data.py`. If it exits non-zero, read the errors, fix `data/events.json`, and run again — repeat until it exits 0. Never open the PR while the validator is red: it is the deterministic gate for schema, link shape, and date order, so let it catch what you missed instead of guessing.
 
-            ## Step 7: Open PR + comment
+            ## Step 7: Add to the pending PR (or open it), then comment
 
-            Branch: `add-event-{id}`. Title: `{name}`. Body:
-            ```
-            ## {name}
+            New events accumulate on ONE rolling pull request labelled `pending-events`, so the maintainer reviews a single PR instead of one per submission. This is **best-effort**: if any git/PR step below fails, fall back to a standalone PR (7c) — never drop a submission, and never merge anything yourself.
 
-            **Category:** {category}
-            **Date:** {date}{ – {date_end} if multi-day}
-            **Organizer:** {organizer}
-            **Link:** {link}
+            ### 7a — Find the pending PR
+            `gh pr list --label pending-events --state open --json number,headRefName --limit 1`
 
-            {why}
+            ### 7b — If one exists, add to it
+            - `git fetch origin <headRefName> && git checkout <headRefName>` — it already holds earlier queued events; keep them all.
+            - Re-apply your Step 6 changes here: insert the entry into `data/events.json` in date order (earliest first), and replace `agent/state/last-events-submission.json`.
+            - Run `python3 scripts/validate_data.py` until it exits 0.
+            - Commit with `--author="Claude <noreply@anthropic.com>"`, then `git push`. If the push is rejected because the branch moved, run `git fetch origin <headRefName> && git reset --hard origin/<headRefName>`, redo the insertion + validation on the fresh state, and push once more. If it still fails, go to 7c.
+            - `gh pr edit <number>`: set the title to `Add {N} student events` (N = entries now on the branch) and append to the body one line `- {name} ({category}, {date})` and, on its own plain-text line, `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` — so merging the single PR closes every contributing issue.
 
-            ---
+            ### 7c — Otherwise (or on any 7b failure), open it
+            - `git checkout -B add-event-pending origin/main`. (On a 7b fallback, use branch `add-event-{id}` and skip the `--label` below — a standalone PR, not the rolling one.)
+            - Insert the entry, validate to green, commit, then `git push -u origin <branch>` (add `--force-with-lease` if the branch already exists from a previously-merged PR).
+            - `gh pr create --label pending-events --title "Add 1 student event: {name}"` with a body holding `- {name} ({category}, {date})` and a plain-text `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` line.
 
-            Closes #${{ github.event.issue.number || github.event.inputs.issue }}
-            ```
-            The Closes line must be plain text (not in a code fence).
-
-            Comment on the issue: "Added **{name}** ({category}, {date}) — {why}\n\nPR: {pr_url}"
+            ### 7d — Comment + close
+            Comment on the issue: "Added **{name}** ({category}, {date}) — {why}\n\nPR: {pr_url}". The merge stays a human decision.

--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
           prompt: |
             You discover student events worth a student's time, remove expired entries, and open one PR with both. Today's date is needed in UTC ISO 8601 — derive it.
 
@@ -91,6 +91,8 @@ jobs:
             ## Step 7: Open one PR
 
             Updated `data/events.json`: remove expired IDs from Step 2, append new entries from Step 6 (in date order earliest first), preserve 2-space indent + trailing newline.
+
+            Then run `python3 scripts/validate_data.py` and fix `data/events.json` until it exits 0 before opening the PR — never open it while the validator is red. It is the deterministic gate for schema, link shape, and date order, so let it catch what you missed instead of guessing.
 
             **Title**: `[Events]: <comma-separated new event names>` (or `Expire stale entries` if only removing)
 

--- a/.github/workflows/maintain-benefits.yml
+++ b/.github/workflows/maintain-benefits.yml
@@ -32,74 +32,34 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
           prompt: |
-            You audit every entry in `data/benefits.json` for link health and quality, fix every finding you can, and open a single PR. Findings go directly to a PR — you don't open issues.
+            You audit every entry in `data/benefits.json`, fix what you can, validate, and open a single PR. Findings go to the PR — never open issues.
 
-            ## Step 1: Read
+            ## The structural gate is `scripts/validate_data.py` — defer to it
 
-            Read `data/benefits.json`. Note today's UTC ISO 8601 date.
+            That script is the source of truth for every mechanical rule: https-only links, no `help.`/`support.`/`docs.`/`blog.` subdomains, no `/articles/` paths, valid `id`/`category`/`offer_type`, ≤120-char descriptions, and id-sort order. Do NOT re-derive these by hand — you'll run the script in Step 4 and fix whatever it flags. Your job is the judgment the script *can't* make:
 
-            ## Step 2: Link health
+            - **Liveness** — does the link actually load? WebFetch each `link` (rate-limit ~1/sec). Treat a clear 404 or network/DNS failure as **broken**; a final URL whose *hostname* differs (cross-domain) as **redirected** (same-domain path changes don't count); skip 403s (usually bot-blocking, not dead).
+            - **Genuine signup page** — is the link the program's own student signup/pricing/overview page, not a marketing homepage (`/`, `/home`) or a doc article? (The script catches forbidden subdomains/paths; you catch bare homepages and "looks official but isn't the offer.")
+            - **Specific offer** — does the description name a real number, plan, or duration (not "student discount available")?
+            - **Self-serve** — flag descriptions gated on an institution ("through your university", "ask your institution", "contact IT").
+            - **Offer-type accuracy** — does `offer_type` match what the description actually says (e.g. "% off" must not be `free`)? The script checks it's a *valid* value; you check it's the *right* one.
 
-            For each benefit, WebFetch its `link`. Classify:
-            - **Broken**: fetch fails (network/DNS), or page is clearly 404. Skip 403s (often bot-blocking).
-            - **Redirected**: final URL's hostname differs from original (cross-domain). Same-domain path changes don't count.
-            - **Healthy**: anything else.
+            Only act on unambiguous cases; when uncertain, leave the entry unchanged.
 
-            Rate-limit to 1 req/sec.
+            ## Step 1: Fix
 
-            ## Step 3: Quality review
+            For a broken/redirected link or a wrong/marketing link: WebSearch `"{name}" student discount signup`, WebFetch the best result, and update `link` to the program's own signup/pricing/overview page. If the program no longer offers a student benefit at all, remove the entry. Fix offer-type mismatches in place; trim over-long descriptions only without losing the offer specifics. Edit `data/benefits.json` directly — preserve 2-space indent, trailing newline, and id-sort order.
 
-            For each benefit, apply the bar. Only flag unambiguous violations; if uncertain, skip.
+            ## Step 2: Validate (required — this is the loop)
 
-            1. **Specific offer**: description must contain a percentage, dollar/credit amount, plan name, or duration. Flag generic descriptions.
-            2. **Direct signup link**: flag if path is exactly `/` or `/home`, or if subdomain is `support.`/`docs.`/`help.`/`blog.`, or if path contains `/articles/`. Help/docs/support articles are documentation, not signup — even when the article title mentions students. URL structure only — don't read page content.
-            3. **Self-serve**: flag if description contains "through your university", "ask your institution", or "contact IT".
-            4. **Offer type accuracy**: flag clear mismatches — description says "% off" / "discount" but `offer_type: free`; or description says "free" but `offer_type: discount`.
-            5. **Description length**: flag `description` exceeding 120 characters.
+            Run `python3 scripts/validate_data.py`. If it exits non-zero, read the errors, fix them, and run again. Repeat until it exits 0. Do not open a PR while the validator is red — a replacement link that trips a forbidden-subdomain or sort error is the validator's job to catch, not yours to memorize.
 
-            ## Step 4: Fix each finding
+            ## Step 3: Open a PR (only if you changed the file)
 
-            **Broken/redirected**: WebSearch `"{name}" student discount signup`, WebFetch top result. If valid student page found → update `link`. If program no longer offers a student program → remove the entry. Redirect destinations that are valid → update `link`; otherwise treat as broken.
+            Branch `maintain-benefits-{YYYY-MM-DD}`, title `[Maintenance]: Fix {N} benefit(s)` (N = entries changed or removed). Body: a one-sentence Summary plus a short table of what changed (benefit, problem, fix) and, separately, anything removed and why. Omit empty sections.
 
-            Any replacement `link` you choose MUST also pass the Step 3 rule #2 structure check — never a `help.`/`support.`/`docs.`/`blog.` subdomain, a `/articles/` path, or a bare homepage (`/` or `/home`), even if it's the top search result. If the only result is a help/docs article, keep searching for the program's own signup/pricing/overview page. A broken link is no excuse to introduce a forbidden one.
+            ## Step 4: Close `link-health` issues
 
-            **Quality flags**:
-            - **Direct signup link**: WebSearch for the direct student signup page; update `link` if found.
-            - **Offer type mismatch**: update `offer_type` to match the description.
-            - **Description length**: trim to ≤120 chars without losing the offer specifics. If trimming would lose meaning, leave unchanged.
-            - **Specific offer** / **Self-serve**: only fix if correct info is clearly findable via WebFetch. If uncertain, leave unchanged.
-
-            ## Step 5: Apply changes
-
-            If any fixes were made, edit `data/benefits.json` — preserve 2-space indent and trailing newline, maintain entry order.
-
-            ## Step 6: Open a PR (only if fixes made)
-
-            **Branch**: `maintain-benefits-{today YYYY-MM-DD}`
-            **Title**: `[Maintenance]: Fix {N} benefit(s)` where N = entries changed or removed.
-            **Body**:
-            ```
-            ## Summary
-
-            <one sentence>
-
-            ### Fixed
-            | Benefit | Issue | Change |
-            |---|---|---|
-            | {name} | {broken / redirected / type mismatch / ...} | {what changed} |
-
-            ### Removed
-            | Benefit | Reason |
-            |---|---|
-            | {name} | Program no longer offers a student benefit |
-            ```
-            Omit empty sections.
-
-            ## Step 7: Close link-health issues
-
-            Find open issues labeled `link-health`. Close each with a comment matching the outcome:
-            - **No findings from Steps 2 or 3**: "All benefits are healthy."
-            - **Findings existed but none fixable**: "Found {N} issue(s) that require manual review: {names}."
-            - **PR was opened**: "Fixed in PR #{pr_number}."
+            Close each open `link-health` issue with the matching outcome: "Fixed in PR #{n}." if a PR was opened; "All benefits are healthy." if nothing needed fixing; or "Found {N} issue(s) that require manual review: {names}." if findings exist that you couldn't safely fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,8 +176,11 @@ the data files) enforces the structural rules below automatically: schema,
 `id`/`category`/`offer_type` validity, ≤120-char descriptions, canonical
 formatting, and the forbidden-link rule (no `help.`/`support.`/`docs.`/`blog.`
 subdomains, `/articles/` paths, or bare homepages). A red check means the data
-is invalid — don't merge. The remaining items below still need a human eye
-(liveness, duplicates, whether the link is genuinely the signup page).
+is invalid — don't merge. (The data-writing workflows now run this same
+validator in-loop and fix what it flags before opening a PR, so a red check
+should be rare — CI is the backstop, not the first line.) The remaining items
+below still need a human eye (liveness, duplicates, whether the link is
+genuinely the signup page).
 
 When reviewing PRs (especially those created by the add-benefit workflow):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,8 @@ Each workflow is a plain GitHub Actions YAML in `.github/workflows/`. The agent 
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `add-benefit.yml` | Issue labeled `new-benefit` | Validates submission, deduplicates, creates PR |
-| `add-event.yml` | Issue labeled `new-event` | Validates against the event quality bar, deduplicates, creates PR |
+| `add-benefit.yml` | Issue labeled `new-benefit` | Validates + deduplicates, then appends to the rolling `pending-benefits` PR (one PR to review) — standalone PR only as a fallback |
+| `add-event.yml` | Issue labeled `new-event` | Validates against the event quality bar + deduplicates, then appends to the rolling `pending-events` PR — standalone PR only as a fallback |
 | `discover-benefits.yml` | Weekly (Monday) or manual | Searches for new student benefits, opens issues for the best finds |
 | `discover-events.yml` | Weekly (Wednesday) or manual | Searches for notable student events, removes expired entries, opens one PR |
 | `maintain-benefits.yml` | Weekly (Sunday) or manual | Audits link health and quality, fixes findings, opens one PR |
@@ -143,6 +143,8 @@ Edit a workflow's `prompt:` directly to change Grant's behavior — no compile s
 When adding a new issue template that introduces a new label, create the GitHub label first — templates auto-apply labels, but only if the label already exists in the repo.
 
 No router/orchestrator yet: the two label-triggered workflows (add-benefit, add-event) both fire on any label event and the non-matching one skips correctly. Revisit a dispatcher at 3+ label-triggered workflows.
+
+**Rolling consolidation PRs.** So the maintainer reviews one PR instead of one-per-submission, `add-benefit`/`add-event` append each new entry to a single open PR labelled `pending-benefits` / `pending-events` (branch `add-benefit-pending` / `add-event-pending`) rather than opening a fresh PR each time. Each contributing issue is referenced with its own plain-text `Closes #N`, so the one merge closes them all. It's **best-effort**: on any git/PR failure (e.g. two runs racing the same branch) the workflow falls back to a standalone PR — a submission is never dropped, at worst you get an extra PR. Consolidation never merges anything; the merge stays the human trust boundary.
 
 ### Falsifiability (scheduled workflows)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Student Benefits Hub
 
-**Grant — a production AI agent powered by Claude — curates a public directory of student discounts.**
+**Grant — an agentic system powered by Claude — curates a directory of student benefits that help you build, learn, and ship.**
 
-Grant discovers new programs each week, validates community submissions opened as issues, and audits link health. Humans approve every merge — the merge is the trust boundary. Run logs and tool traces are open. **[→ student-benefits.github.io](https://student-benefits.github.io)**
+Grant is a set of workflows, a deterministic validation gate, and a human who merges — not one autonomous agent. It discovers new programs each week, validates community submissions opened as issues, and audits link health. Every change is checked by the gate and approved by a person before it goes live — the merge is the trust boundary. Run logs and tool traces are open. **[→ student-benefits.github.io](https://student-benefits.github.io)**
 
 [![Live](https://img.shields.io/badge/live-student--benefits.github.io-blue)](https://student-benefits.github.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)

--- a/agent/agent.css
+++ b/agent/agent.css
@@ -769,3 +769,138 @@ body {
   .identity-name { font-size: 1.75rem; }
   .trace-head-detail { display: none; }
 }
+
+/* ── gate actor (green; reuses the unused tavily ramp) ── */
+:root {
+  --gate-color:  #1a7a4a;
+  --gate-bg:     #f0faf4;
+  --gate-border: #b8e0c8;
+}
+.arch-node--gate { border-color: var(--gate-border); color: var(--gate-color); background: var(--gate-bg); }
+.arch-node--gate[aria-expanded="true"] { box-shadow: 0 0 0 2px var(--gate-color); }
+.actor-gate .trace-dot { border-color: var(--gate-color); background: var(--gate-color); }
+.badge-gate { background: var(--gate-bg); color: var(--gate-color); border: 1px solid var(--gate-border); }
+
+/* ── the loop (thesis device) ─────────────────────────── */
+.loop {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  position: relative;
+  padding: 1.75rem 1.5rem 2.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+.loop-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid;
+  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  min-width: 8.5rem;
+  flex: 1 1 8.5rem;
+}
+.loop-stage-k { font-size: 0.85rem; font-weight: 700; }
+.loop-stage-v { font-size: 0.75rem; color: var(--text-muted); }
+.loop-stage--gen   { border-color: var(--grant-border); color: var(--grant-color); }
+.loop-stage--gate  { border-color: var(--gate-border);  color: var(--gate-color); }
+.loop-stage--human { border-color: var(--github-border); color: var(--github-color); }
+.loop-link {
+  position: relative;
+  flex: 0 0 2.25rem;
+  height: 2px;
+  background: var(--border);
+  align-self: center;
+}
+.loop-link::after {
+  content: ''; position: absolute; right: -1px; top: 50%;
+  width: 6px; height: 6px;
+  border-top: 2px solid var(--border); border-right: 2px solid var(--border);
+  transform: translateY(-50%) rotate(45deg);
+}
+.loop-link--pass, .loop-link--pass::after { background: var(--gate-color); border-color: var(--gate-color); }
+.loop-link-l {
+  position: absolute; top: -1.1rem; left: 50%; transform: translateX(-50%);
+  font-size: 0.62rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;
+  white-space: nowrap; color: var(--text-muted);
+}
+.loop-link--pass .loop-link-l { color: var(--gate-color); }
+.loop-live {
+  align-self: center; font-size: 0.8rem; font-weight: 700; color: var(--gate-color);
+  padding-left: 0.35rem; white-space: nowrap;
+}
+.loop-iterate {
+  position: absolute; left: 1.5rem; right: 30%; bottom: 0.75rem; height: 1rem;
+  border: 1.5px solid var(--grant-border); border-top: none;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+}
+.loop-iterate-l {
+  position: absolute; left: 50%; bottom: -0.55rem; transform: translateX(-50%);
+  font-size: 0.62rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--grant-color); background: var(--surface); padding: 0 0.4rem; white-space: nowrap;
+}
+.loop-caption { margin-top: 1rem; font-size: 0.85rem; color: var(--text-muted); max-width: 540px; line-height: 1.6; }
+
+/* ── workflow↔agent spectrum ──────────────────────────── */
+.spectrum-lede {
+  font-size: 0.95rem; color: var(--text-muted); max-width: 560px; line-height: 1.65; margin-bottom: 1.75rem;
+}
+.spectrum-lede strong { color: var(--text); }
+.spectrum-axis { display: flex; align-items: center; gap: 0.75rem; }
+.spectrum-end {
+  display: flex; flex-direction: column; line-height: 1.2;
+  font-size: 0.78rem; font-weight: 700; white-space: nowrap;
+}
+.spectrum-end small { font-weight: 400; font-size: 0.65rem; color: var(--text-muted); }
+.spectrum-end--l { color: var(--gate-color); }
+.spectrum-end--r { color: var(--github-color); text-align: right; }
+.spectrum-line {
+  flex: 1; height: 2px; border-radius: 2px;
+  background: linear-gradient(90deg, var(--gate-color), var(--border) 55%, var(--github-color));
+}
+.spectrum-marks { list-style: none; position: relative; height: 7rem; margin-top: 1.5rem; }
+.mark {
+  position: absolute; left: var(--x); top: 0; transform: translateX(-50%);
+  display: flex; flex-direction: column; align-items: center; gap: 0.45rem;
+  width: max-content; max-width: 9.5rem;
+}
+.mark:nth-child(even) { top: 3.4rem; }
+.mark-dot {
+  width: 9px; height: 9px; border-radius: 50%; background: var(--grant-color);
+  box-shadow: 0 0 0 4px var(--grant-bg);
+}
+.mark-dot--gate { background: var(--gate-color); box-shadow: 0 0 0 4px var(--gate-bg); }
+.mark-l { display: flex; flex-direction: column; align-items: center; gap: 0.15rem; text-align: center; }
+.mark-l code { font-size: 0.72rem; }
+.mark-l small { font-size: 0.66rem; color: var(--text-muted); line-height: 1.3; }
+
+/* code chips inline */
+code {
+  font-family: var(--mono); font-size: 0.85em;
+  background: var(--surface-raised); border: 1px solid var(--border-subtle);
+  border-radius: var(--radius); padding: 0.05em 0.32em; color: var(--text);
+}
+.identity-desc em, .node-panel em, .spectrum-lede em, .loop-caption em { font-style: normal; font-weight: 600; color: var(--text); }
+.identity-desc strong, .node-panel strong { color: var(--text); }
+
+.footer-sources { margin-bottom: 0.6rem; }
+
+@media (max-width: 600px) {
+  .loop { flex-direction: column; align-items: stretch; }
+  .loop-stage { flex: none; }
+  .loop-link { width: 2px; height: 1.4rem; flex-basis: 1.4rem; align-self: center; }
+  .loop-link::after { right: 50%; top: auto; bottom: -1px; transform: translateX(50%) rotate(135deg); }
+  .loop-link-l { top: 50%; left: 1rem; transform: translateY(-50%); }
+  .loop-live { align-self: flex-start; padding-left: 0; }
+  .loop-iterate { display: none; }
+  .spectrum-marks { height: auto; display: grid; gap: 0.7rem; }
+  .mark { position: static; transform: none; flex-direction: row; align-items: center; gap: 0.6rem; max-width: none; }
+  .mark:nth-child(even) { top: 0; }
+  .mark-l { align-items: flex-start; text-align: left; }
+  .spectrum-line { background: var(--border); }
+}

--- a/agent/agent.js
+++ b/agent/agent.js
@@ -1,47 +1,51 @@
+/* agent.js — drives the /agent/ explainer:
+   (1) architecture node disclosures, (2) the simulated submission, (3) the live last-run trace. */
+
 const TOOLS = {
-  get_issue:             { actor: 'github', label: 'GitHub',        explain: 'Reads the GitHub issue to extract the submitted benefit name and any optional details.' },
-  get_file_contents:     { actor: 'github', label: 'GitHub',        explain: 'Downloads <code>data/benefits.json</code> from the repo to check whether this benefit is already listed.' },
-  create_or_update_file: { actor: 'github', label: 'GitHub',        explain: 'Writes or updates a file in the repository via the GitHub API.' },
-  create_pull_request:   { actor: 'github', label: 'GitHub',        explain: 'Creates a GitHub pull request with the change for human review before it goes live.' },
-  add_comment:           { actor: 'github', label: 'GitHub',        explain: 'Posts a status comment on the original issue to close the loop with the submitter.' },
-  close_issue:           { actor: 'github', label: 'GitHub',        explain: null },
-  create_issue:          { actor: 'github', label: 'GitHub',        explain: 'Opens a new GitHub issue for a discovered student program, queuing it for the add-benefit workflow to process.' },
-  'github-issue_read':   { actor: 'github', label: 'GitHub',        explain: 'Reads the GitHub issue to extract the submitted benefit name and any optional details.' },
-  websearch:             { actor: 'web',    label: 'Web Search',    explain: 'Runs a live web search (Claude Code’s built-in WebSearch tool) to verify the student program exists and find the official signup URL.' },
-  web_fetch:             { actor: 'web',    label: 'Web Fetch',     explain: 'Opens the most relevant search result (Claude Code’s built-in WebFetch tool) to confirm the student program details and extract the correct URL.' },
-  webfetch:              { actor: 'web',    label: 'Web Fetch',     explain: 'Opens the most relevant search result (Claude Code’s built-in WebFetch tool) to confirm the student program details and extract the correct URL.' },
-  edit:                  { actor: 'grant',  label: 'Grant',         explain: 'Appends the new benefit entry to <code>data/benefits.json</code> in the repository.' },
+  get_issue:             { actor: 'github', label: 'GitHub',     explain: 'Reads the GitHub issue to extract the submitted benefit name and any optional details.' },
+  get_file_contents:     { actor: 'github', label: 'GitHub',     explain: 'Downloads <code>data/benefits.json</code> from the repo to check whether this benefit is already listed.' },
+  create_or_update_file: { actor: 'github', label: 'GitHub',     explain: 'Writes or updates a file in the repository via the GitHub API.' },
+  create_pull_request:   { actor: 'github', label: 'GitHub',     explain: 'Creates a GitHub pull request with the change for human review before it goes live.' },
+  add_comment:           { actor: 'github', label: 'GitHub',     explain: 'Posts a status comment on the original issue to close the loop with the submitter.' },
+  close_issue:           { actor: 'github', label: 'GitHub',     explain: null },
+  create_issue:          { actor: 'github', label: 'GitHub',     explain: 'Opens a new GitHub issue for a discovered student program, queuing it for the add-benefit workflow.' },
+  'github-issue_read':   { actor: 'github', label: 'GitHub',     explain: 'Reads the GitHub issue to extract the submitted benefit name and any optional details.' },
+  websearch:             { actor: 'web',    label: 'Web Search', explain: 'Runs a live web search (Claude’s built-in WebSearch) to verify the student program exists and find the official signup URL.' },
+  web_fetch:             { actor: 'web',    label: 'Web Fetch',  explain: 'Opens the most relevant result (Claude’s built-in WebFetch) to confirm the program details and extract the correct URL.' },
+  webfetch:              { actor: 'web',    label: 'Web Fetch',  explain: 'Opens the most relevant result (Claude’s built-in WebFetch) to confirm the program details and extract the correct URL.' },
+  validate_data:         { actor: 'gate',   label: 'Gate',       explain: 'Runs <code>validate_data.py</code> — the deterministic gate. Exit 0/1 is the loop’s pass/fail signal.' },
+  edit:                  { actor: 'grant',  label: 'Grant',      explain: 'Writes the new benefit entry into <code>data/benefits.json</code> in sorted position.' },
 };
 
-function toggleDisclosure(panelId, triggerId, allPanelsSelector, allTriggersSelector) {
-  const panel   = document.getElementById(panelId);
-  const trigger = document.getElementById(triggerId);
-  const isOpen  = !panel.hidden;
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}
 
-  document.querySelectorAll(allPanelsSelector).forEach(function (p) { p.hidden = true; });
-  document.querySelectorAll(allTriggersSelector).forEach(function (t) { t.setAttribute('aria-expanded', 'false'); });
-
-  if (!isOpen) {
+/* ── architecture node disclosures ────────────────────── */
+function togglePanel(id) {
+  const panel = document.getElementById('panel-' + id);
+  const trigger = document.getElementById('node-' + id);
+  const open = !panel.hidden;
+  document.querySelectorAll('.node-panel').forEach(p => { p.hidden = true; });
+  document.querySelectorAll('.arch-node').forEach(t => t.setAttribute('aria-expanded', 'false'));
+  if (!open) {
     panel.hidden = false;
-    panel.style.animation = 'none';
-    panel.offsetHeight; // force reflow to restart CSS animation
-    panel.style.animation = '';
+    panel.style.animation = 'none'; panel.offsetHeight; panel.style.animation = '';
     trigger.setAttribute('aria-expanded', 'true');
   }
 }
 
-function toggleProp(id) {
-  toggleDisclosure('ppanel-' + id, 'pchip-' + id, '[id^="ppanel-"]', '.prop-chip');
-}
+document.querySelector('.arch-nodes').addEventListener('click', e => {
+  const btn = e.target.closest('.arch-node');
+  if (btn) togglePanel(btn.id.replace('node-', ''));
+});
 
-function togglePanel(id) {
-  toggleDisclosure('panel-' + id, 'node-' + id, '.node-panel', '.arch-node');
-}
-
-
+/* ── live run trace ───────────────────────────────────── */
 function fmtDetail(tool) {
-  if (tool.query) return 'query: ' + tool.query;
-  if (tool.url)   return tool.url.replace(/^https?:\/\//, '');
+  if (tool.query)   return 'query: ' + tool.query;
+  if (tool.url)     return tool.url.replace(/^https?:\/\//, '');
   if (tool.summary) return tool.summary;
   return '';
 }
@@ -55,15 +59,8 @@ function fmtTime(iso) {
   } catch { return iso; }
 }
 
-const OUTCOME_LABELS = {
-  accepted:  '✓ Accepted',
-  rejected:  '✗ Rejected',
-  duplicate: '⚠ Duplicate'
-};
-
-function outcomeLabel(outcome) {
-  return OUTCOME_LABELS[outcome] || outcome;
-}
+const OUTCOME_LABELS = { accepted: '✓ Accepted', rejected: '✗ Rejected', duplicate: '⚠ Duplicate' };
+function outcomeLabel(o) { return OUTCOME_LABELS[o] || o; }
 
 function renderRun(data) {
   const issueUrl = `https://github.com/student-benefits/student-benefits.github.io/issues/${data.issue}`;
@@ -83,43 +80,30 @@ function renderRun(data) {
   if (data.benefit) {
     html += `<span class="benefit-pill"><strong>${escapeHtml(data.benefit.name)}</strong> · ${escapeHtml(data.benefit.category)}</span>`;
   }
-
   if (data.run_url) {
     html += `<a class="run-link" href="${escapeHtml(data.run_url)}" target="_blank" rel="noopener noreferrer">View run →</a>`;
   }
-
-  html += `</div></div>`;
-
-  // Trace
-  html += `<div class="trace">`;
+  html += `</div></div><div class="trace">`;
 
   for (const tool of (data.tools || [])) {
-    const info = TOOLS[tool.name] || { actor: 'grant', label: tool.name, explain: null };
-    const badge = 'badge-' + info.actor;
-    const stepClass = 'actor-' + info.actor;
-    const explain = info.explain || '';
+    const info   = TOOLS[tool.name] || { actor: 'grant', label: tool.name, explain: null };
     const detail = fmtDetail(tool);
-
     html += `
-      <div class="trace-step ${escapeHtml(stepClass)}">
-        <div class="trace-gutter">
-          <div class="trace-dot"></div>
-          <div class="trace-line"></div>
-        </div>
+      <div class="trace-step actor-${escapeHtml(info.actor)}">
+        <div class="trace-gutter"><div class="trace-dot"></div><div class="trace-line"></div></div>
         <div class="trace-card">
           <div class="trace-head">
-            <span class="actor-badge ${escapeHtml(badge)}">${escapeHtml(info.label)}</span>
-            <span class="trace-head-label">${escapeHtml(tool.name.replace(/_/g, '_\u200b'))}</span><!-- allow line-break after underscores in long tool names -->
+            <span class="actor-badge badge-${escapeHtml(info.actor)}">${escapeHtml(info.label)}</span>
+            <span class="trace-head-label">${escapeHtml(tool.name.replace(/_/g, '_​'))}</span>
             ${detail ? `<span class="trace-head-detail">${escapeHtml(detail)}</span>` : ''}
           </div>
           <div class="trace-body">
             ${tool.summary ? `<p class="trace-primary">${escapeHtml(tool.summary)}</p>` : ''}
-            ${explain ? `<p class="trace-annotation">${explain}</p>` : ''}
+            ${info.explain ? `<p class="trace-annotation">${info.explain}</p>` : ''}
           </div>
         </div>
       </div>`;
   }
-
   html += `</div>`;
 
   if (data.benefit && data.outcome === 'accepted') {
@@ -133,11 +117,10 @@ function renderRun(data) {
 
   document.getElementById('run-output').innerHTML = html;
   applyPacketRates(data.tools || [], data.outcome);
-  renderOrbitDots(data.tools || []);
 }
 
+/* packet speed encodes how often each connector was used in the last run */
 function applyPacketRates(tools, outcome) {
-  // conn-search and conn-validate: speed encodes call frequency
   const counts = { web: 0, github: 0 };
   for (const t of tools) {
     const actor = (TOOLS[t.name] || {}).actor || 'grant';
@@ -146,7 +129,6 @@ function applyPacketRates(tools, outcome) {
   }
   setPacketRate('conn-search',   counts.web);
   setPacketRate('conn-validate', counts.github);
-  // conn-pr: binary — PR either went to reviewer or it didn't
   setPacketRate('conn-pr', outcome === 'accepted' ? 1 : 0);
 }
 
@@ -162,94 +144,44 @@ function setPacketRate(id, count) {
   }
 }
 
-const ACTOR_COLOR = {
-  grant:  'var(--grant-color)',
-  github: 'var(--github-color)',
-  web:    'var(--web-color)',
-};
-
-// Replaces static orbit dots with one dot per tool step (capped at 8).
-// Dot color = actor type; distribution encodes the composition of the last run.
-function renderOrbitDots(tools) {
-  const center = document.querySelector('.prop-radial-center');
-  if (!center) return;
-  center.querySelectorAll('.orbit-dot').forEach(d => d.remove());
-  const steps = tools.slice(0, 8);
-  if (!steps.length) return;
-  const period = 10; // seconds per orbit
-  const nameEl = center.querySelector('.prop-radial-center-name');
-  steps.forEach((tool, i) => {
-    const actor = (TOOLS[tool.name] || {}).actor || 'grant';
-    const dot = document.createElement('span');
-    dot.className = 'orbit-dot';
-    dot.style.background = ACTOR_COLOR[actor] || ACTOR_COLOR.grant;
-    dot.style.animationDelay = (-period * i / steps.length).toFixed(2) + 's';
-    dot.title = actor + ': ' + tool.name;
-    center.insertBefore(dot, nameEl);
-  });
-}
-
-// Simulation
+/* ── simulated submission ─────────────────────────────── */
 const SIM_STEPS = [
-  {
-    stepClass: 'actor-github', badge: 'badge-github', badgeLabel: 'GitHub',
-    headLabel: 'get_issue', detail: 'issue #67',
+  { stepClass: 'actor-github', badge: 'badge-github', badgeLabel: 'GitHub', headLabel: 'get_issue', detail: 'issue #67',
     primary: 'User submitted: <em>"Adobe Creative Cloud is discounted for students"</em>',
-    annotation: 'Reads the issue body to extract the benefit name and any optional link provided by the submitter.'
-  },
-  {
-    stepClass: 'actor-github', badge: 'badge-github', badgeLabel: 'GitHub',
-    headLabel: 'get_file_contents', detail: 'data/benefits.json',
+    annotation: 'Reads the issue body to extract the benefit name and any optional link.' },
+  { stepClass: 'actor-github', badge: 'badge-github', badgeLabel: 'GitHub', headLabel: 'get_file_contents', detail: 'data/benefits.json',
     primary: '… existing benefits loaded. Checking for name and hostname matches…',
-    annotation: 'Scans all existing entries before doing any web research to avoid duplicates.'
-  },
-  {
-    stepClass: 'actor-grant', badge: 'badge-grant', badgeLabel: 'Grant',
-    headLabel: 'no duplicate found', detail: null,
-    primary: '<code>adobe.com</code> not in existing entries. Proceeding to verify.',
-    annotation: null
-  },
-  {
-    stepClass: 'actor-web', badge: 'badge-web', badgeLabel: 'Web',
-    headLabel: 'websearch', detail: 'Adobe Creative Cloud student discount education',
-    primary: '5 results found. Top result: <code>adobe.com/creativecloud/plans/student-and-teacher.html</code>',
-    annotation: 'Searches the live web to confirm the program is real and currently active. Not just from training data.'
-  },
-  {
-    stepClass: 'actor-web', badge: 'badge-web', badgeLabel: 'Web',
-    headLabel: 'web_fetch', detail: 'adobe.com/creativecloud/plans/student-and-teacher.html',
+    annotation: 'Scans existing entries before any web research, to avoid duplicates.' },
+  { stepClass: 'actor-grant', badge: 'badge-grant', badgeLabel: 'Grant', headLabel: 'no duplicate found', detail: null,
+    primary: '<code>adobe.com</code> not in existing entries. Proceeding to verify.', annotation: null },
+  { stepClass: 'actor-web', badge: 'badge-web', badgeLabel: 'Web', headLabel: 'websearch', detail: 'Adobe Creative Cloud student discount',
+    primary: '5 results. Top: <code>adobe.com/creativecloud/plans/student-and-teacher.html</code>',
+    annotation: 'Searches the live web to confirm the program is real and active — not just from training data.' },
+  { stepClass: 'actor-web', badge: 'badge-web', badgeLabel: 'Web', headLabel: 'web_fetch', detail: 'adobe.com/…/student-and-teacher.html',
     primary: 'Confirmed: ~65% discount on Creative Cloud All Apps for verified students.',
-    annotation: 'Opens the actual signup page to extract exact terms and the correct URL.'
-  },
-  {
-    stepClass: 'actor-grant', badge: 'badge-grant', badgeLabel: 'Grant',
-    headLabel: 'edit', detail: 'data/benefits.json',
-    primary: 'Added <strong>Adobe Creative Cloud</strong> · Design',
+    annotation: 'Opens the actual signup page to extract exact terms and the correct URL.' },
+  { stepClass: 'actor-grant', badge: 'badge-grant', badgeLabel: 'Grant', headLabel: 'edit', detail: 'data/benefits.json',
+    primary: 'Wrote <strong>Adobe Creative Cloud</strong> · Design',
     code: `<span class="c-dim">{</span>
   <span class="c-hl">"id"</span>: <span class="c-grn">"adobe-creative-cloud"</span>,
   <span class="c-hl">"name"</span>: <span class="c-grn">"Adobe Creative Cloud"</span>,
   <span class="c-hl">"category"</span>: <span class="c-grn">"Design"</span>,
-  <span class="c-hl">"description"</span>: <span class="c-grn">"~65% discount on All Apps plan for students..."</span>,
+  <span class="c-hl">"offer_type"</span>: <span class="c-grn">"discount"</span>,
   <span class="c-hl">"popularity"</span>: <span class="c-blue">5</span>
 <span class="c-dim">}</span>`,
-    annotation: 'Appends the validated benefit with all required fields to data/benefits.json.'
-  },
-  {
-    stepClass: 'actor-github', badge: 'badge-github', badgeLabel: 'GitHub',
-    headLabel: 'create_pull_request', detail: 'PR #68',
+    annotation: 'Writes the entry into data/benefits.json in sorted position.' },
+  { stepClass: 'actor-gate', badge: 'badge-gate', badgeLabel: 'Gate', headLabel: 'validate_data.py', detail: 'exit 0',
+    primary: 'Schema, link shape, and sort order all <strong>pass</strong>.',
+    annotation: 'The deterministic gate runs before any PR. On a fail, Grant fixes the entry and re-runs — that is the loop.' },
+  { stepClass: 'actor-github', badge: 'badge-github', badgeLabel: 'GitHub', headLabel: 'create_pull_request', detail: 'PR #68',
     primary: 'Opened PR #68: <em>"Add benefit: Adobe Creative Cloud"</em>',
-    annotation: 'Creates a pull request for human review. The benefit goes live only after it\'s merged.'
-  },
-  {
-    stepClass: 'actor-github', badge: 'badge-github', badgeLabel: 'GitHub',
-    headLabel: 'add_comment', detail: 'issue #67',
+    annotation: 'Creates a pull request for human review. The benefit goes live only after a person merges.' },
+  { stepClass: 'actor-github', badge: 'badge-github', badgeLabel: 'GitHub', headLabel: 'add_comment', detail: 'issue #67',
     primary: 'Commented on issue #67 with the PR link.',
-    annotation: 'Closes the loop. The submitter gets notified their suggestion was processed.'
-  }
+    annotation: 'Closes the loop with the submitter.' }
 ];
 
 let simStep = 0;
-
 const SVG_PLAY   = `<svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>`;
 const SVG_NEXT   = `<svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>`;
 const SVG_REPLAY = `<svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>`;
@@ -260,14 +192,10 @@ function simNext() {
   const trace = document.getElementById('sim-trace');
 
   if (btn.dataset.state === 'replay') {
-    trace.innerHTML = '';
-    simStep = 0;
-    btn.dataset.state = '';
-    btn.innerHTML = SVG_PLAY + ' Start';
-    hint.textContent = '';
+    trace.innerHTML = ''; simStep = 0; btn.dataset.state = '';
+    btn.innerHTML = SVG_PLAY + ' Start'; hint.textContent = '';
     return;
   }
-
   if (simStep >= SIM_STEPS.length) return;
 
   addSimStep(SIM_STEPS[simStep], trace, btn);
@@ -275,26 +203,19 @@ function simNext() {
   hint.textContent = `${simStep} / ${SIM_STEPS.length}`;
 
   if (simStep === SIM_STEPS.length) {
-    btn.dataset.state = 'replay';
-    btn.innerHTML = SVG_REPLAY + ' Replay';
+    btn.dataset.state = 'replay'; btn.innerHTML = SVG_REPLAY + ' Replay';
   } else {
     btn.innerHTML = SVG_NEXT + ' Next step';
   }
 }
 
-// SIM_STEPS fields: badge, badgeLabel, headLabel, detail are plain text — escaped below.
-// primary, code, annotation are authored HTML in the SIM_STEPS constant — injected raw intentionally.
+// headLabel/detail/badge are escaped; primary/code/annotation are authored HTML, injected raw on purpose.
 function addSimStep(step, trace, btn) {
-  const codeHtml = step.code
-    ? `<div class="sim-code"><pre>${step.code}</pre></div>`
-    : '';
+  const codeHtml = step.code ? `<div class="sim-code"><pre>${step.code}</pre></div>` : '';
   const el = document.createElement('div');
   el.className = `trace-step ${step.stepClass} sim-hidden`;
   el.innerHTML = `
-    <div class="trace-gutter">
-      <div class="trace-dot"></div>
-      <div class="trace-line"></div>
-    </div>
+    <div class="trace-gutter"><div class="trace-dot"></div><div class="trace-line"></div></div>
     <div class="trace-card">
       <div class="trace-head">
         <span class="actor-badge ${escapeHtml(step.badge)}">${escapeHtml(step.badgeLabel)}</span>
@@ -309,35 +230,21 @@ function addSimStep(step, trace, btn) {
     </div>`;
   trace.appendChild(el);
   requestAnimationFrame(() => requestAnimationFrame(() => {
-    el.classList.remove('sim-hidden');
-    el.classList.add('sim-visible');
+    el.classList.remove('sim-hidden'); el.classList.add('sim-visible');
     if (btn) btn.scrollIntoView({ behavior: 'smooth', block: 'end' });
   }));
 }
 
-document.querySelector('.arch-nodes').addEventListener('click', function (e) {
-  const btn = e.target.closest('.arch-node');
-  if (!btn) return;
-  togglePanel(btn.id.replace('node-', ''));
-});
-
-document.querySelector('.prop-radial').addEventListener('click', function (e) {
-  const chip = e.target.closest('.prop-chip');
-  if (!chip) return;
-  toggleProp(chip.id.replace('pchip-', ''));
-});
-
 document.getElementById('sim-btn').addEventListener('click', simNext);
 
 fetch('../data/benefits.json')
-  .then(function (r) { return r.ok ? r.json() : []; })
-  .then(function (data) {
-    SIM_STEPS[1].primary = data.length + ' existing benefits loaded. Checking for name and hostname matches\u2026';
-  });
+  .then(r => r.ok ? r.json() : [])
+  .then(data => { SIM_STEPS[1].primary = data.length + ' existing benefits loaded. Checking for name and hostname matches…'; })
+  .catch(() => {});
 
 fetch('state/last-run.json')
-  .then(function (r) { if (!r.ok) throw new Error(r.status); return r.json(); })
-  .then(function (data) {
+  .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
+  .then(data => {
     renderRun(data);
     const meta = document.getElementById('run-summary-meta');
     if (meta) {
@@ -346,7 +253,7 @@ fetch('state/last-run.json')
         `<span class="run-summary-issue">Issue #${escapeHtml(String(data.issue))} — ${escapeHtml(data.title)}</span>`;
     }
   })
-  .catch(function () {
+  .catch(() => {
     document.getElementById('run-output').innerHTML =
-      '<div class="state-error">No run data yet. Grant hasn\'t processed a submission yet.</div>';
+      '<div class="state-error">No run recorded yet.</div>';
   });

--- a/agent/index.html
+++ b/agent/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#f5f5f0">
-  <meta name="description" content="Grant is the AI agent that curates Student Benefits Hub. See how it works and what it did last.">
+  <meta name="description" content="Grant curates Student Benefits Hub with Claude — an agentic system built from workflows, a deterministic gate, and a human in the loop. See the loop, in the field's own terms.">
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
-  <title>Grant · AI Agent · Student Benefits Hub</title>
+  <title>Grant · How the loop works · Student Benefits Hub</title>
   <link rel="stylesheet" href="/agent/agent.css">
 </head>
 <body>
@@ -23,16 +23,47 @@
 
 <main class="main">
 
+  <!-- ── identity ─────────────────────────────────────── -->
   <section class="identity">
     <h1 class="identity-name">Grant</h1>
-    <p class="identity-role">AI agent · <a href="https://claude.ai" target="_blank" rel="noopener noreferrer">Claude Sonnet 4.6</a> · Student Benefits Hub</p>
+    <p class="identity-role">Agentic system · <a href="https://claude.ai" target="_blank" rel="noopener noreferrer">Claude Sonnet 4.6</a> · Student Benefits Hub</p>
     <p class="identity-desc">
-      Grant is an AI agent that curates this directory by verifying submissions, searching the web for new student programs, and opening pull requests. It runs on a schedule to discover and add benefits without waiting for a human to suggest them. A human reviews and merges every PR — Grant handles correctness, the reviewer exercises judgment.
+      Grant keeps this directory current. It’s tempting to call it “an AI agent,” but the honest version is
+      smaller and more interesting: a few <strong>workflows</strong> that each run Claude on a fixed path,
+      a deterministic <strong>gate</strong> that checks every change, and a <strong>human</strong> who merges.
+      That restraint is the design.
     </p>
   </section>
 
+  <!-- ── the loop (thesis) ────────────────────────────── -->
   <section class="section">
-    <p class="section-label">Architecture</p>
+    <p class="section-label">The loop</p>
+    <div class="loop" role="img" aria-label="The build loop: Claude generates a change, a gate verifies it, the loop iterates on failure, and a human merges a passing change to go live.">
+      <div class="loop-stage loop-stage--gen">
+        <span class="loop-stage-k">generate</span>
+        <span class="loop-stage-v">Claude writes a change</span>
+      </div>
+      <span class="loop-link"><span class="loop-link-l">proposes</span></span>
+      <div class="loop-stage loop-stage--gate">
+        <span class="loop-stage-k">verify</span>
+        <span class="loop-stage-v">the gate checks it</span>
+      </div>
+      <span class="loop-link loop-link--pass"><span class="loop-link-l">pass</span></span>
+      <div class="loop-stage loop-stage--human">
+        <span class="loop-stage-k">merge</span>
+        <span class="loop-stage-v">a human ships it</span>
+      </div>
+      <span class="loop-live">live</span>
+      <span class="loop-iterate"><span class="loop-iterate-l">fail → iterate</span></span>
+    </div>
+    <p class="loop-caption">
+      Generate, verify, and iterate until the gate passes — then a person merges. Everything below is this loop, in detail.
+    </p>
+  </section>
+
+  <!-- ── architecture ─────────────────────────────────── -->
+  <section class="section">
+    <p class="section-label">Architecture <span class="section-label-tag">tap a node</span></p>
     <div class="arch-diagram" role="region" aria-label="Interactive architecture diagram. Click any node to learn what it does.">
       <div class="arch-nodes">
 
@@ -43,7 +74,7 @@
           </button>
           <button class="arch-node arch-node--github" id="node-schedule" aria-expanded="false" aria-controls="panel-schedule">
             <span class="arch-node-label">Schedule</span>
-            <span class="arch-node-sublabel">Mon, Wed + Sun weekly</span>
+            <span class="arch-node-sublabel">weekly cron</span>
           </button>
         </div>
 
@@ -55,7 +86,7 @@
         <div class="arch-node-wrap">
           <button class="arch-node arch-node--grant" id="node-grant" aria-expanded="false" aria-controls="panel-grant">
             <span class="arch-node-label">Grant</span>
-            <span class="arch-node-sublabel">Claude Sonnet 4.6</span>
+            <span class="arch-node-sublabel">augmented LLM</span>
           </button>
         </div>
 
@@ -78,14 +109,25 @@
 
         <div class="arch-connector" id="conn-validate" aria-hidden="true">
           <span class="packet packet-req"></span>
+          <span class="arch-connector-label">writes entry</span>
+        </div>
+
+        <div class="arch-node-wrap">
+          <button class="arch-node arch-node--gate" id="node-gate" aria-expanded="false" aria-controls="panel-gate">
+            <span class="arch-node-label">Gate</span>
+            <span class="arch-node-sublabel">validate_data.py</span>
+          </button>
+        </div>
+
+        <div class="arch-connector" id="conn-gate" aria-hidden="true">
           <span class="packet packet-res"></span>
-          <span class="arch-connector-label">validated entry</span>
+          <span class="arch-connector-label">pass</span>
         </div>
 
         <div class="arch-node-wrap">
           <button class="arch-node arch-node--github" id="node-output" aria-expanded="false" aria-controls="panel-output">
             <span class="arch-node-label">GitHub</span>
-            <span class="arch-node-sublabel">PR · issue · comment</span>
+            <span class="arch-node-sublabel">PR · comment</span>
           </button>
         </div>
 
@@ -106,124 +148,73 @@
       <div class="node-panels-slot">
         <div id="panel-issue" class="node-panel" hidden>
           <p class="node-panel-title">GitHub Issue</p>
-          <p>Anyone can suggest a benefit by opening an issue. When it's labeled <code>new-benefit</code>, GitHub fires a webhook that starts Grant. The title and body are the only inputs. Everything else Grant discovers on its own.</p>
+          <p>Anyone can suggest a benefit by opening an issue. When it’s labeled <code>new-benefit</code>, GitHub fires a webhook that starts a workflow. The title and body are the only inputs — everything else Grant finds on its own.</p>
         </div>
         <div id="panel-schedule" class="node-panel" hidden>
-          <p class="node-panel-title">Weekly Schedule</p>
-          <p>Three scheduled workflows run without human prompting. On Mondays, <code>discover-benefits</code> searches the web for new student programs and opens GitHub issues for the best discoveries — feeding Grant's own queue. On Wednesdays, <code>discover-events</code> searches for notable student events, removes expired entries, and opens PRs directly. On Sundays, <code>maintain-benefits</code> checks every existing entry for broken links and quality issues, fixes what it can, and opens a PR with the changes.</p>
-          <p>Two issue-triggered workflows process community submissions. <code>add-benefit</code> fires when an issue is labeled <code>new-benefit</code>; <code>add-event</code> fires when an issue is labeled <code>new-event</code>. Both validate the submission, check for duplicates, and open a PR — or comment and close the issue if the submission doesn't pass.</p>
+          <p class="node-panel-title">Weekly schedule</p>
+          <p>Scheduled workflows run without a human prompting them. <code>discover-benefits</code> searches for new programs and opens issues for the best ones; <code>discover-events</code> finds student events; <code>maintain-benefits</code> audits every link and fixes what it can. Each is a <strong>workflow</strong> — Claude on a fixed path, not a free-roaming agent.</p>
         </div>
         <div id="panel-grant" class="node-panel" hidden>
-          <p class="node-panel-title">Grant · Claude Sonnet 4.6</p>
-          <p>The orchestrator. Grant reads the issue, decides which tools to call, interprets the results, and determines the outcome without human approval of intermediate steps. Its output depends on the workflow and the outcome — a PR, a comment, a closed issue, or a combination. Its instructions are a Markdown file checked into this repository.</p>
+          <p class="node-panel-title">Grant · the augmented LLM</p>
+          <p>The building block Anthropic calls the <em>augmented LLM</em>: Claude plus a few tools, reasoning step by step. It reads the issue, decides which tool to call next, and writes the change — but it can’t publish. Its instructions are a plain Markdown prompt checked into the repo.</p>
         </div>
         <div id="panel-search" class="node-panel" hidden>
           <p class="node-panel-title">Web Search</p>
-          <p>Claude Code’s built-in <code>WebSearch</code> tool. Grant calls it to verify whether a student program exists by searching the live web beyond its training data, returning candidate results Grant can reason over directly.</p>
+          <p>Claude’s built-in <code>WebSearch</code> tool. Grant calls it to confirm a student program actually exists on the live web — beyond training data — and returns candidate results it can reason over.</p>
         </div>
         <div id="panel-web" class="node-panel" hidden>
           <p class="node-panel-title">Web Fetch</p>
-          <p>Claude Code’s built-in <code>WebFetch</code> tool. After Web Search returns candidate URLs, Grant fetches the actual pages to confirm the program is real, active, and has a direct student signup link. The link Grant records must be one it loaded successfully in the same run — never a path guessed from the product name — so dead URLs don’t reach a PR. Read-only. No forms submitted, no side effects.</p>
+          <p>Claude’s built-in <code>WebFetch</code> tool. Grant opens the actual page to confirm the program is real and grab the correct signup link. The link it records must be one it loaded in the same run — never a path guessed from the name — so dead URLs don’t reach a PR. Read-only, no side effects.</p>
+        </div>
+        <div id="panel-gate" class="node-panel" hidden>
+          <p class="node-panel-title">The gate · <code>validate_data.py</code></p>
+          <p>A deterministic check — no LLM. It runs against every change and exits <code>0</code> (pass) or <code>1</code> (fail) on schema, link shape, and sort order. This is the loop’s <strong>verifiable environment</strong>: <em>resettable</em> (re-runs each attempt), <em>efficient</em> (offline, sub-second), and <em>rewardable</em> (an automatic pass/fail). It’s what lets Grant iterate against a real signal instead of grading its own work.</p>
         </div>
         <div id="panel-output" class="node-panel" hidden>
-          <p class="node-panel-title">GitHub Output</p>
-          <p>Grant's outputs depend on the workflow. For benefit and event submissions: if valid and new, it opens a pull request and comments on the issue; if rejected or duplicate, it comments with the reason and closes the issue. For <code>discover-benefits</code>: it opens new issues for the best discoveries it found. For <code>discover-events</code>: it opens a PR directly. For <code>maintain-benefits</code>: it fixes broken links and quality flags directly in <code>data/benefits.json</code> and opens a PR. All writes go through GitHub's API. PRs wait for a human reviewer to merge — Grant cannot publish directly.</p>
+          <p class="node-panel-title">GitHub output</p>
+          <p>Once the gate passes, Grant opens a pull request and comments on the issue. For a rejection or duplicate it comments the reason and closes the issue. Every write goes through GitHub’s API — and stops short of merging.</p>
         </div>
         <div id="panel-human" class="node-panel" hidden>
-          <p class="node-panel-title">Human Reviewer</p>
-          <p>Grant cannot merge its own pull requests. Each workflow runs with a scoped GitHub Actions <code>permissions:</code> block (<code>contents</code>, <code>issues</code>, <code>pull-requests</code>) — enough to commit to a branch, open a PR, and comment, but not to merge. The merge itself is gated by <code>CODEOWNERS</code> and branch protection, so it stays a human decision. Grant handles correctness (format, links, duplicates); the reviewer exercises judgment (editorial fit, quality).</p>
+          <p class="node-panel-title">Human reviewer</p>
+          <p>Grant can’t merge its own PRs. Each workflow runs with a scoped <code>permissions:</code> block — enough to branch, open a PR, and comment, never to merge. The merge is held by <code>CODEOWNERS</code> and branch protection, so going live is always a person’s call. Grant handles correctness; the reviewer handles judgment.</p>
         </div>
       </div>
     </div>
   </section>
 
+  <!-- ── workflow ↔ agent spectrum (replaces "what makes this an agent?") -->
   <section class="section">
-    <p class="section-label">What makes this an agent?</p>
-
-    <div class="prop-radial" role="region" aria-label="Agent properties. Click any dimension to learn more.">
-      <div class="prop-radial-center" aria-hidden="true">
-        <span class="prop-radial-center-name">Grant</span>
-        <span class="prop-radial-center-sub">AI agent</span>
+    <p class="section-label">Workflow or agent?</p>
+    <p class="spectrum-lede">
+      Anthropic draws one line: a <strong>workflow</strong> runs Claude on a path you wrote; an
+      <strong>agent</strong> directs its own path. Each piece of Grant sits closer to one end. The honest
+      answer is “mostly workflow” — and that’s the point.
+    </p>
+    <div class="spectrum" role="img" aria-label="A spectrum from workflow (predefined path) to agent (self-directing). Grant's pieces cluster toward the workflow end.">
+      <div class="spectrum-axis">
+        <span class="spectrum-end spectrum-end--l">workflow<small>predefined path</small></span>
+        <span class="spectrum-line"></span>
+        <span class="spectrum-end spectrum-end--r">agent<small>self-directing</small></span>
       </div>
-
-      <button class="prop-chip prop-radial-node" id="pchip-tool" style="left:50%;top:14%" aria-expanded="false">
-        <svg class="prop-chip-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>
-        Tool use
-      </button>
-      <button class="prop-chip prop-radial-node" id="pchip-decision" style="left:70%;top:32%" aria-expanded="false">
-        <svg class="prop-chip-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v9m0 0l-4 4m4-4l4 4M8 20h8"/></svg>
-        Decision-making
-      </button>
-      <button class="prop-chip prop-radial-node" id="pchip-autonomy" style="left:70%;top:68%" aria-expanded="false">
-        <svg class="prop-chip-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
-        Autonomy
-      </button>
-      <button class="prop-chip prop-radial-node" id="pchip-memory" style="left:50%;top:86%" aria-expanded="false">
-        <svg class="prop-chip-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><ellipse cx="12" cy="7" rx="8" ry="2.5"/><path stroke-linecap="round" stroke-linejoin="round" d="M4 7v5c0 1.38 3.58 2.5 8 2.5s8-1.12 8-2.5V7"/><path stroke-linecap="round" stroke-linejoin="round" d="M4 12v5c0 1.38 3.58 2.5 8 2.5s8-1.12 8-2.5v-5"/></svg>
-        Memory
-      </button>
-      <button class="prop-chip prop-radial-node" id="pchip-self" style="left:30%;top:68%" aria-expanded="false">
-        <svg class="prop-chip-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
-        Self-direction
-      </button>
-      <button class="prop-chip prop-radial-node" id="pchip-oversight" style="left:30%;top:32%" aria-expanded="false">
-        <svg class="prop-chip-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
-        Human oversight
-      </button>
+      <ul class="spectrum-marks">
+        <li class="mark" style="--x:6%"><span class="mark-dot mark-dot--gate"></span><span class="mark-l"><code>validate-data</code><small>the gate · no LLM</small></span></li>
+        <li class="mark" style="--x:30%"><span class="mark-dot"></span><span class="mark-l"><code>add-benefit</code><small>prompt chaining + gate</small></span></li>
+        <li class="mark" style="--x:50%"><span class="mark-dot"></span><span class="mark-l"><code>maintain-benefits</code><small>evaluator-optimizer</small></span></li>
+        <li class="mark" style="--x:68%"><span class="mark-dot"></span><span class="mark-l"><code>discover-benefits</code><small>bounded search</small></span></li>
+      </ul>
     </div>
-
-    <div class="prop-detail-slot">
-      <div id="ppanel-tool" class="node-panel" hidden>
-        <p class="node-panel-title">Tool use</p>
-        <p>An agent selects tools based on what it finds, not a fixed sequence. Grant calls GitHub, web search, and web fetch in an order that varies with every submission.</p>
-      </div>
-      <div id="ppanel-decision" class="node-panel" hidden>
-        <p class="node-panel-title">Decision-making</p>
-        <p>An agent uses LLM reasoning to choose a path at each step, not a fixed branching script. Every submission ends in one of three outcomes:</p>
-        <div class="outcomes-grid">
-          <div class="outcome-card accepted">
-            <p class="outcome-label">✓ Accepted</p>
-            <p class="outcome-desc">Real program, not a duplicate. PR opened, issue commented.</p>
-          </div>
-          <div class="outcome-card rejected">
-            <p class="outcome-label">✗ Rejected</p>
-            <p class="outcome-desc">No student program found, or the benefit is a consumption perk rather than build &amp; grow. Issue closed, domain logged.</p>
-          </div>
-          <div class="outcome-card duplicate">
-            <p class="outcome-label">⚠ Duplicate</p>
-            <p class="outcome-desc">Already in directory. Issue closed with a pointer to existing entry.</p>
-          </div>
-        </div>
-      </div>
-      <div id="ppanel-autonomy" class="node-panel" hidden>
-        <p class="node-panel-title">Autonomy</p>
-        <p>An agent runs end-to-end without a human approving intermediate steps. Grant goes from issue trigger to PR without any checkpoint — but the merge is held for a human. Grant controls how the process runs; humans decide what goes live.</p>
-      </div>
-      <div id="ppanel-memory" class="node-panel" hidden>
-        <p class="node-panel-title">Memory</p>
-        <p>An agent persists state across runs. Grant saves rejected programs in <code>state/rejected.json</code>. Future submissions for the same product skip re-verification entirely.</p>
-      </div>
-      <div id="ppanel-self" class="node-panel" hidden>
-        <p class="node-panel-title">Self-direction</p>
-        <p>An agent generates its own tasks rather than waiting for human input. Grant runs weekly, searches for new student benefits, and creates issues for itself to process.</p>
-      </div>
-      <div id="ppanel-oversight" class="node-panel" hidden>
-        <p class="node-panel-title">Human oversight</p>
-        <p>Grant cannot merge or push to <code>main</code> — every benefit that goes live required a human to approve it. The run log on this page exists so review is informed, not a rubber stamp: a reviewer can see exactly what Grant searched, fetched, and reasoned before deciding.</p>
-      </div>
-    </div>
-
   </section>
 
+  <!-- ── simulated run ────────────────────────────────── -->
   <section class="section">
-    <p class="section-label">How it works <span class="section-label-tag">simulated</span></p>
+    <p class="section-label">Watch a submission <span class="section-label-tag">simulated</span></p>
 
     <div class="sim-task">
       <div class="sim-task-head">
         <span class="sim-task-label">GitHub Issue</span>
         <span class="sim-task-num">#67</span>
       </div>
-      <div class="sim-task-body"><strong>"Adobe Creative Cloud is discounted for students"</strong></div>
+      <div class="sim-task-body"><strong>“Adobe Creative Cloud is discounted for students”</strong></div>
     </div>
 
     <div class="trace" id="sim-trace" aria-live="polite" aria-label="Simulated agent trace"></div>
@@ -237,14 +228,15 @@
     </div>
   </section>
 
-  <section class="section" id="run-section">
-    <details class="run-details" id="run-details">
-      <summary class="run-summary">
-        <span class="section-label">Last run</span>
+  <!-- ── last run ─────────────────────────────────────── -->
+  <section class="section">
+    <details class="run-details">
+      <summary>
+        <span class="section-label">Last real run</span>
         <span class="run-summary-meta" id="run-summary-meta"></span>
       </summary>
-      <div id="run-output">
-        <div class="state-loading">Loading run data…</div>
+      <div id="run-output" class="run-output">
+        <div class="state-loading">Loading the last run…</div>
       </div>
     </details>
   </section>
@@ -252,10 +244,15 @@
 </main>
 
 <footer class="site-footer">
-  <p>Grant is open source. <a href="https://github.com/student-benefits/student-benefits.github.io/tree/main/.github/workflows" target="_blank" rel="noopener noreferrer">Read the workflows</a> to see exactly what it does, or open an issue to suggest a new benefit or event and watch it run for real.</p>
+  <p class="footer-sources">
+    Built on published practice —
+    <a href="https://www.anthropic.com/research/building-effective-agents" target="_blank" rel="noopener noreferrer">Building Effective Agents</a>,
+    <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" target="_blank" rel="noopener noreferrer">Effective Harnesses</a>, and
+    <a href="https://karpathy.bearblog.dev/verifiability/" target="_blank" rel="noopener noreferrer">Karpathy on Verifiability</a>.
+  </p>
+  <p>Grant is open source. <a href="https://github.com/student-benefits/student-benefits.github.io" target="_blank" rel="noopener noreferrer">Read the workflows</a> to see exactly what it does, or open an issue and watch it run for real.</p>
 </footer>
 
-<script src="/assets/shared.js"></script>
 <script src="/agent/agent.js"></script>
 </body>
 </html>

--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
 """Validate data/benefits.json and data/events.json against the schema.
 
-Deterministic gate for the data integrity rules in CLAUDE.md. Runs in CI on
-every PR that touches the data files, so the rules hold regardless of which
-workflow (or which model) produced the change.
+Deterministic gate (Anthropic, "Building Effective Agents") for the data
+integrity rules in CLAUDE.md. Runs in CI on every PR that touches the data
+files, so the rules hold regardless of which workflow (or which model) produced
+the change.
+
+It is also the maintain-benefits loop's verifiable environment (Karpathy,
+"Verifiability"): resettable (re-runnable on every attempt), efficient (offline,
+sub-second), and rewardable (exit 0/1 is an automated pass/fail). That is what
+lets the agent generate -> check -> fix until green instead of guessing — the
+loop iterates against a real reward signal, not self-assessment.
 
 Checks structure and URL shape only — never fetches links. Liveness is the
 maintain-benefits workflow's job; this gate is about what we can prove offline.


### PR DESCRIPTION
## Summary

Aligns the system, and the page that explains it, with published agent-loop practice.

**1. Run the validator in-loop in every data-writing workflow** (`maintain-benefits`, `add-benefit`, `add-event`, `discover-events`)
- Each now runs `scripts/validate_data.py` and iterates until it exits 0 *before* opening a PR, instead of leaving CI to catch invalid data afterward. Tightly-scoped `Bash(python3 scripts/validate_data.py)` permission.
- `maintain-benefits` no longer restates the schema/forbidden-link rules — the validator is the single source of truth; the agent fixes whatever it flags.
- `validate_data.py`'s docstring names what it is: the deterministic **gate** and the loop's **verifiable environment** (resettable, efficient, rewardable).
- `discover-benefits` unchanged — it only opens issues, writes no data.

**2. Redesign `/agent/`** (`index.html`, `agent.css`, `agent.js`)
- Reframes honestly: an **agentic system** of workflows + a gate + a human in the loop, not "an AI agent."
- Leads with the **generate → verify → iterate** loop; adds the **gate** node to the architecture diagram and a real `validate_data.py` step to the simulated run.
- Replaces the agent-properties radial with an honest **workflow → agent spectrum**; names patterns by their published terms; links the sources.
- Keeps the warm visual system, interactive diagram, and live last-run trace; defines the previously-missing `escapeHtml` helper.

## Test plan
- `/agent/` rendered locally at 1280px and 390px — clean reflow; zero console errors; node disclosures + the simulation verified.
- All four workflow YAMLs parse; each prompt runs the validator before opening its PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)