### PR TITLE
Consolidate stacked benefits PRs: add 11, fix 7, remove 2 dead

### DIFF
--- a/agent/state/last-benefits-discovery.json
+++ b/agent/state/last-benefits-discovery.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-06-08T17:30:42Z",
+  "timestamp": "2026-07-06T00:00:00Z",
   "known_sources_checked": [
     "https://education.github.com/pack/offers",
     "https://www.jetbrains.com/community/education/",
@@ -20,31 +20,11 @@
     "site:reddit.com \"student discount\" developer OR design tools 2026"
   ],
   "discovered": [
-    {
-      "name": "Adafruit",
-      "link": "https://www.adafruit.com/github-students",
-      "source": "known-source"
-    },
-    {
-      "name": "Adobe Creative Cloud",
-      "link": "https://www.adobe.com/creativecloud/buy/students.html",
-      "source": "keyword"
-    },
-    {
-      "name": "PopSQL",
-      "link": "https://popsql.com/github-students",
-      "source": "known-source"
-    },
-    {
-      "name": "Travis CI",
-      "link": "https://www.travis-ci.com/education/",
-      "source": "known-source"
-    },
-    {
-      "name": "Stripe",
-      "link": "https://education.github.com/pack/redeem/stripe-student",
-      "source": "known-source"
-    }
+    { "name": "ConfigCat", "link": "https://configcat.com/student/", "source": "known-source" },
+    { "name": "Camber", "link": "https://www.cambercloud.com/github-student-pack", "source": "known-source" },
+    { "name": "OpenAI Codex", "link": "https://developers.openai.com/community/students", "source": "keyword" },
+    { "name": "ToDiagram", "link": "https://todiagram.com/education", "source": "known-source" },
+    { "name": "Algolia", "link": "https://www.algolia.com/blog/algolia/github-student-developer-pack", "source": "known-source" }
   ],
   "issues_created": 5
 }

--- a/agent/state/last-run.json
+++ b/agent/state/last-run.json
@@ -1,13 +1,12 @@
 {
-  "issue": 275,
-  "title": "codescene",
-  "timestamp": "2026-06-29T00:00:00Z",
+  "issue": 300,
+  "title": "blackfire",
+  "timestamp": "2026-07-20T00:00:00Z",
   "outcome": "accepted",
   "tools": [
-    { "name": "websearch", "query": "CodeScene student discount GitHub Student Pack education program" },
-    { "name": "webfetch", "url": "https://codescene.com/github-students" },
-    { "name": "webfetch", "url": "https://codescene.com/resources/github-students" },
+    { "name": "websearch", "query": "Blackfire student discount education program 2026" },
+    { "name": "webfetch", "url": "https://www.blackfire.io/students" },
     { "name": "edit", "summary": "Added entry to data/benefits.json" }
   ],
-  "benefit": { "name": "CodeScene", "category": "Dev Tools", "description": "Free student account with code health analysis, technical debt visualization, IDE extensions, and automated PR reviews." }
+  "benefit": { "name": "Blackfire", "category": "Dev Tools", "description": "Free Developer plan for 1 year (€348 value) — PHP and Python profiling with SQL and HTTP request analysis." }
 }

--- a/data/benefits.json
+++ b/data/benefits.json
@@ -57,6 +57,35 @@
     "popularity": 7
   },
   {
+    "id": "algolia",
+    "name": "Algolia",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "100k records and 1M search operations/month free for 1 year via GitHub Student Pack.",
+    "link": "https://education.github.com/pack",
+    "tags": [
+      "Search",
+      "API",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "appfigures",
+    "name": "Appfigures",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free app analytics and ASO tools for 1 year — metrics, keyword intelligence, and competitor analysis.",
+    "link": "https://appfigures.com/landing/github-student",
+    "tags": [
+      "Analytics",
+      "App Store",
+      "Mobile",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
     "id": "apple-education",
     "name": "Apple Education Pricing",
     "category": "Hardware",
@@ -142,6 +171,21 @@
     "popularity": 9
   },
   {
+    "id": "blackfire",
+    "name": "Blackfire",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free Developer plan for 1 year (€348 value) — PHP and Python profiling with SQL and HTTP request analysis.",
+    "link": "https://www.blackfire.io/students",
+    "tags": [
+      "GitHub Student Pack",
+      "Profiling",
+      "PHP",
+      "Python"
+    ],
+    "popularity": 5
+  },
+  {
     "id": "boot-dev",
     "name": "Boot.dev",
     "category": "Learning",
@@ -184,6 +228,21 @@
     "popularity": 5
   },
   {
+    "id": "camber",
+    "name": "Camber",
+    "category": "Cloud & Hosting",
+    "offer_type": "free",
+    "description": "Free Student plan: 200 CPU hours, 75 GB storage, and 200 LLM messages/month for scientific computing.",
+    "link": "https://www.cambercloud.com/github-student-pack",
+    "tags": [
+      "GitHub Student Pack",
+      "Cloud",
+      "HPC",
+      "AI"
+    ],
+    "popularity": 5
+  },
+  {
     "id": "canva",
     "name": "Canva for Education",
     "category": "Design",
@@ -196,6 +255,21 @@
       "Marketing"
     ],
     "popularity": 9
+  },
+  {
+    "id": "carto",
+    "name": "CARTO",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free account with increased storage, real-time data, Location Data Services credits, and premium features for 2 years.",
+    "link": "https://app.carto.com/students",
+    "tags": [
+      "Geospatial",
+      "Maps",
+      "Data Analytics",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
   },
   {
     "id": "clerk",
@@ -270,19 +344,18 @@
     "popularity": 5
   },
   {
-    "id": "cursor-pro",
-    "name": "Cursor Pro",
-    "category": "AI Tools",
+    "id": "configcat",
+    "name": "ConfigCat",
+    "category": "Dev Tools",
     "offer_type": "free",
-    "description": "Free year of Cursor Pro for verified university students. AI code editor with 500 fast requests/month.",
-    "link": "https://cursor.com/students",
+    "description": "Free Pro plan while enrolled — manage up to 1,000 feature flags with unlimited seats for classmates.",
+    "link": "https://configcat.com/student/",
     "tags": [
-      "AI",
-      "Editor",
-      "IDE"
+      "Feature Flags",
+      "Dev Tools",
+      "GitHub Student Pack"
     ],
-    "popularity": 9,
-    "repo": "getcursor/cursor"
+    "popularity": 5
   },
   {
     "id": "dashlane",
@@ -331,8 +404,8 @@
     "name": "Deepnote",
     "category": "Dev Tools",
     "offer_type": "free",
-    "description": "Free Team plan for collaborative data notebooks while enrolled. Unlimited collaborators and Basic machine hours.",
-    "link": "https://deepnote.com/docs/student",
+    "description": "Free Education plan for students while enrolled. Browser-based collaborative notebooks with unlimited team members.",
+    "link": "https://deepnote.com/education",
     "tags": [
       "Data Science",
       "Jupyter",
@@ -352,21 +425,6 @@
       "Software Licensing",
       "Dev Tools",
       "GitHub Student Pack"
-    ],
-    "popularity": 5
-  },
-  {
-    "id": "digitalocean",
-    "name": "DigitalOcean",
-    "category": "Cloud & Hosting",
-    "offer_type": "credits",
-    "description": "$200 in platform credit for 1 year via GitHub Student Pack. Usable on Droplets, Kubernetes, and Managed Databases.",
-    "link": "https://www.digitalocean.com/landing/github-students",
-    "tags": [
-      "Cloud",
-      "Hosting",
-      "GitHub Student Pack",
-      "Kubernetes"
     ],
     "popularity": 5
   },
@@ -404,7 +462,7 @@
     "name": "Evernote Student",
     "category": "Productivity",
     "offer_type": "discount",
-    "description": "40% off Evernote Professional via UNiDAYS verification. Note-taking with AI search, PDF annotation, and sync.",
+    "description": "40% off Evernote Advanced Annual plan via UNiDAYS verification. Note-taking with AI search, PDF annotation, and sync.",
     "link": "https://evernote.com/unidays",
     "tags": [
       "Notes",
@@ -531,8 +589,8 @@
     "id": "grammarly",
     "name": "Grammarly",
     "category": "Productivity",
-    "offer_type": "discount",
-    "description": "Student discounts available via SheerID/UNiDAYS verification. Free Premium tier plus AI features for students.",
+    "offer_type": "free",
+    "description": "Free AI writing assistant for students with grammar check, style suggestions, and AI-powered writing tools.",
     "link": "https://www.grammarly.com/students",
     "tags": [
       "Writing",
@@ -547,7 +605,7 @@
     "category": "Learning",
     "offer_type": "discount",
     "description": "10-20% off student subscription for cybersecurity training. Hands-on labs, challenges, and career-focused content.",
-    "link": "https://academy.hackthebox.com/billing",
+    "link": "https://academy.hackthebox.com/faq",
     "tags": [
       "Cybersecurity",
       "Hacking",
@@ -589,7 +647,7 @@
     "category": "Learning",
     "offer_type": "free",
     "description": "Free 1000+ courses in AI, cybersecurity, cloud, and data science. Earn industry-recognized credentials.",
-    "link": "https://skillsbuild.org/students",
+    "link": "https://skillsbuild.org/college-students",
     "tags": [
       "Courses",
       "Certifications",
@@ -674,8 +732,8 @@
     "name": "Loom Education",
     "category": "Productivity",
     "offer_type": "discount",
-    "description": "50-75% off Loom for verified students and educators. Unlimited recordings, HD quality, and full editing tools.",
-    "link": "https://www.loom.com/use-case/education",
+    "description": "75% off Loom Business plan for eligible students and educators. Apply via Atlassian classroom license form.",
+    "link": "https://www.atlassian.com/licensing/purchase-licensing",
     "tags": [
       "Video",
       "Recording",
@@ -869,6 +927,20 @@
     "repo": "obsidianmd/obsidian-releases"
   },
   {
+    "id": "openai-codex-students",
+    "name": "OpenAI Codex for Students",
+    "category": "AI Tools",
+    "offer_type": "credits",
+    "description": "$100 in Codex credits (2,500 credits) for AI-powered coding; valid 12 months. US and Canada only.",
+    "link": "https://developers.openai.com/community/students",
+    "tags": [
+      "AI Coding",
+      "Credits",
+      "Coding Assistant"
+    ],
+    "popularity": 5
+  },
+  {
     "id": "oracle-cloud",
     "name": "Oracle Cloud",
     "category": "Cloud & Hosting",
@@ -984,6 +1056,20 @@
     "popularity": 5
   },
   {
+    "id": "retool",
+    "name": "Retool",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free Team or Business plan for students with .edu email — build internal tools, admin panels, and dashboards.",
+    "link": "https://retool.com/pricing",
+    "tags": [
+      "Dev Tools",
+      "No-Code",
+      "Internal Tools"
+    ],
+    "popularity": 5
+  },
+  {
     "id": "samsung-education",
     "name": "Samsung Education",
     "category": "Hardware",
@@ -1060,10 +1146,25 @@
     "category": "Dev Tools",
     "offer_type": "free",
     "description": "Waived transaction fees on first $1,000 in revenue processed.",
-    "link": "https://education.github.com/pack/redeem/stripe-student",
+    "link": "https://education.github.com/pack",
     "tags": [
       "Payments",
       "Dev Tools",
+      "GitHub Student Pack"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "symfonycasts",
+    "name": "SymfonyCasts",
+    "category": "Learning",
+    "offer_type": "trial",
+    "description": "Free 3-month subscription to all PHP and Symfony video tutorial courses (worth $75).",
+    "link": "https://symfonycasts.com/github-student",
+    "tags": [
+      "PHP",
+      "Symfony",
+      "Video Tutorials",
       "GitHub Student Pack"
     ],
     "popularity": 5
@@ -1079,6 +1180,34 @@
       "SSH",
       "Terminal",
       "GitHub"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "testmu-ai",
+    "name": "TestMu AI",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free Live-1 parallel plan for 1 year — unlimited manual cross-browser testing, screenshots, and local tunnel testing.",
+    "link": "https://www.testmuai.com/github-students/",
+    "tags": [
+      "Cross-Browser Testing",
+      "GitHub Student Pack",
+      "Testing"
+    ],
+    "popularity": 5
+  },
+  {
+    "id": "todiagram",
+    "name": "ToDiagram",
+    "category": "Dev Tools",
+    "offer_type": "free",
+    "description": "Free Pro plan via GitHub Student Pack — convert JSON, YAML, CSV, and XML to interactive diagrams; 200 cloud docs.",
+    "link": "https://todiagram.com/education",
+    "tags": [
+      "Diagrams",
+      "Data Visualization",
+      "GitHub Student Pack"
     ],
     "popularity": 5
   },


### PR DESCRIPTION
## Summary

Four `maintain-benefits` runs (#291, #299, #303, #308) and a `discover-benefits` cycle (#288/#289) piled up unmerged, all branched off the same base commit — each week's audit re-found overlapping issues independently, some with conflicting proposed values. This PR is the deduplicated union, applied to current `main`.

**Added** (from #289 — 11 new benefits): Algolia, Appfigures, Blackfire, Camber, CARTO, ConfigCat, OpenAI Codex for Students, Retool, SymfonyCasts, TestMu AI, ToDiagram

**Removed** (verified live 2026-08-11):
- Cursor Pro — `cursor.com/students` no longer offers a free Pro plan (#291)
- DigitalOcean — GitHub Student Pack program ended; confirmed absent from both `digitalocean.com/landing/github-students` and `education.github.com/pack` (#303)

**Fixed** (deduped where 2+ audits touched the same field with different proposed values — kept the most-corroborated or independently-reverified one):
- Deepnote — link + description → `deepnote.com/education` (#299 and #308 independently agreed; #291 and #303 each proposed different URLs)
- Evernote Student — plan renamed "Advanced" (#299's more specific "Advanced Annual plan" over #291's "Advanced")
- Hack The Box — link to public FAQ instead of login-walled billing page (#291, #303 agreed)
- IBM SkillsBuild — link to `/college-students` (#291, #303 agreed)
- Stripe — link to pack hub (#303)
- Loom Education — link + description post-Atlassian-acquisition (#308)
- Grammarly — `offer_type` discount→free. #299 made this change; #291 and #308 explicitly flagged it as uncertain/left-unchanged. Reverified live: grammarly.com/students has no SheerID/UNiDAYS gate, just the universal free plan — #299 was correct.

## Supersedes

Closes #289, #291, #299, #303, #308, #288 (all folded into this PR).

## Test plan
- [x] `python3 scripts/validate_data.py` passes