### PR TITLE
Fix scout-reddit.yml: push after claude-code-action revokes its token

### DIFF
--- a/.github/workflows/scout-reddit.yml
+++ b/.github/workflows/scout-reddit.yml
@@ -113,10 +113,16 @@ jobs:
 
       - name: Commit state changes
         if: github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add agent/state/reddit-state.json
           git diff --cached --quiet && exit 0
           git commit -m "Update Reddit scout state"
-          git push
+          # claude-code-action revokes its own GitHub App installation token as a
+          # post-step cleanup, and that revocation kills the credential helper this
+          # step would otherwise inherit — push explicitly with the job's own
+          # GITHUB_TOKEN instead of relying on ambient git auth state.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" HEAD:main


### PR DESCRIPTION
## Summary

`scout-reddit.yml`'s scheduled run has hard-failed every single week for 10 consecutive weeks (2026-06-05 through 2026-08-07) with:
```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/student-benefits/student-benefits.github.io.git/'
```
That's why `agent/state/reddit-state.json`'s `last_run` has been stuck since March — the CLAUDE.md working-when criterion for this workflow was already flagging it as suspect.

## Root cause

The workflow deliberately has Claude leave its file edits uncommitted (`Do NOT commit or push — leave any file edits in the workspace; a later step pushes them.`), then a separate shell step commits and pushes afterward. But `claude-code-action` revokes its own GitHub App installation token as a post-step cleanup ("Revoke app token"), and that step runs *before* the later "Commit state changes" step — so by the time the manual push happens, the credential it's relying on is already dead.

## Fix

Push explicitly using the job's own `GITHUB_TOKEN` (the job already has `permissions: contents: write`) instead of relying on ambient git credential state left over from the Claude step.

## Test plan
- [x] YAML syntax validated
- [ ] Trigger manually (`gh workflow run scout-reddit.yml -f dry_run=false`) after merge to confirm the push succeeds