### PR TITLE
Fix discover-events.yml: specify a fixed branch name

### DIFF
--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -94,6 +94,8 @@ jobs:
 
             Then run `python3 scripts/validate_data.py` and fix `data/events.json` until it exits 0 before opening the PR — never open it while the validator is red. It is the deterministic gate for schema, link shape, and date order, so let it catch what you missed instead of guessing.
 
+            **Branch**: `discover-events-{YYYY-MM-DD}` (today's date) — never reuse or invent another name; this keeps each week's run on its own branch so runs never race each other.
+
             **Title**: `[Events]: <comma-separated new event names>` (or `Expire stale entries` if only removing)
 
             **Body**:


### PR DESCRIPTION
## Summary

`discover-events.yml`'s prompt never told Claude what branch to open its PR from — unlike `maintain-benefits.yml`, which explicitly specifies `maintain-benefits-{YYYY-MM-DD}`. Left to invent a name each run, recent runs drifted onto `add-events-pending` and `add-event-pending` — branch names that collide with `add-event.yml`'s own rolling-PR convention.

Confirmed by reading the actual content of #307 and #313: both were `discover-events` output (state-file diffs, "Why these events" reasoning, the discovery prompt's exact PR body shape), not `add-event` submissions, despite the misleading branch names.

## Fix

Pin the branch to `discover-events-{YYYY-MM-DD}`, matching the pattern `maintain-benefits.yml` already uses successfully.

## Test plan
- [x] YAML syntax validated
- [ ] Confirm next scheduled/manual run uses the pinned branch name