### PR TITLE
Redesign submission flow: per-issue PRs, deterministic consolidation, redispatch safety net

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -127,24 +127,13 @@ jobs:
 
             Run `python3 scripts/validate_data.py`. If it exits non-zero, read the errors, fix `data/benefits.json`, and run again — repeat until it exits 0. Never open the PR while the validator is red: it is the deterministic gate for schema, link shape, and sort order, so let it catch what you missed instead of guessing.
 
-            ## Step 6: Add to the pending PR (or open it), then comment
+            ## Step 6: Open a PR, then comment
 
-            New benefits accumulate on ONE rolling pull request labelled `pending-benefits`, so the maintainer reviews a single PR instead of one per submission. This is **best-effort**: if any git/PR step below fails, fall back to a standalone PR (6c) — never drop a submission, and never merge anything yourself.
+            Every run gets its own branch and its own standalone PR — never share a branch with another run, and never force-push or reset one. A separate deterministic workflow (`consolidate-pending.yml`, no Claude involved) batches these into one PR for the maintainer to review on its own schedule; your only job here is a clean, self-contained PR for this one entry.
 
-            ### 6a — Find the pending PR
-            `gh pr list --label pending-benefits --state open --json number,headRefName --limit 1`
-
-            ### 6b — If one exists, add to it
-            - `git fetch origin <headRefName> && git checkout <headRefName>` — it already holds earlier queued benefits; keep them all.
-            - Re-apply your Step 5 changes here: insert the entry into `data/benefits.json` in `id`-sorted position, and replace `agent/state/last-run.json`.
+            - `git checkout -B add-benefit-${{ github.event.issue.number || github.event.inputs.issue }} origin/main`
+            - Insert the entry into `data/benefits.json` in its `id`-sorted position (per Step 5), and replace `agent/state/last-run.json` (per Step 5).
             - Run `python3 scripts/validate_data.py` until it exits 0.
-            - Commit with `--author="Claude <noreply@anthropic.com>"`, then `git push`. If the push is rejected because the branch moved, run `git fetch origin <headRefName> && git reset --hard origin/<headRefName>`, redo the insertion + validation on the fresh state, and push once more. If it still fails, go to 6c.
-            - `gh pr edit <number>`: set the title to `Add {N} student benefits` (N = entries now on the branch) and append to the body one line `- {name} ({category})` and, on its own plain-text line, `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` — so merging the single PR closes every contributing issue.
-
-            ### 6c — Otherwise (or on any 6b failure), open it
-            - `git checkout -B add-benefit-pending origin/main`. (On a 6b fallback, use branch `add-benefit-{id}` and skip the `--label` below — a standalone PR, not the rolling one.)
-            - Insert the entry, validate to green, commit, then `git push -u origin <branch>` (add `--force-with-lease` if the branch already exists from a previously-merged PR).
+            - Commit with `--author="Claude <noreply@anthropic.com>"`, then `git push -u origin add-benefit-${{ github.event.issue.number || github.event.inputs.issue }}`. This branch is new and unique to this issue — the push should never be rejected; if it somehow is, stop and comment "**Could not open a PR:** {reason}" rather than attempting any reset/force-push recovery.
             - `gh pr create --label pending-benefits --title "Add 1 student benefit: {name}"` with a body holding `- {name} ({category})` and a plain-text `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` line.
-
-            ### 6d — Comment + close
-            Comment on the issue: "Added **{name}** ({category}) — {description}\n\nPR: {pr_url}". The merge stays a human decision.
+            - Comment on the issue: "Added **{name}** ({category}) — {description}\n\nPR: {pr_url}". The merge stays a human decision.

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -103,24 +103,13 @@ jobs:
 
             Run `python3 scripts/validate_data.py`. If it exits non-zero, read the errors, fix `data/events.json`, and run again — repeat until it exits 0. Never open the PR while the validator is red: it is the deterministic gate for schema, link shape, and date order, so let it catch what you missed instead of guessing.
 
-            ## Step 7: Add to the pending PR (or open it), then comment
+            ## Step 7: Open a PR, then comment
 
-            New events accumulate on ONE rolling pull request labelled `pending-events`, so the maintainer reviews a single PR instead of one per submission. This is **best-effort**: if any git/PR step below fails, fall back to a standalone PR (7c) — never drop a submission, and never merge anything yourself.
+            Every run gets its own branch and its own standalone PR — never share a branch with another run, and never force-push or reset one. A separate deterministic workflow (`consolidate-pending.yml`, no Claude involved) batches these into one PR for the maintainer to review on its own schedule; your only job here is a clean, self-contained PR for this one entry.
 
-            ### 7a — Find the pending PR
-            `gh pr list --label pending-events --state open --json number,headRefName --limit 1`
-
-            ### 7b — If one exists, add to it
-            - `git fetch origin <headRefName> && git checkout <headRefName>` — it already holds earlier queued events; keep them all.
-            - Re-apply your Step 6 changes here: insert the entry into `data/events.json` in date order (earliest first), and replace `agent/state/last-events-submission.json`.
+            - `git checkout -B add-event-${{ github.event.issue.number || github.event.inputs.issue }} origin/main`
+            - Insert the entry into `data/events.json` in date order (earliest first), per Step 6, and replace `agent/state/last-events-submission.json` per Step 6.
             - Run `python3 scripts/validate_data.py` until it exits 0.
-            - Commit with `--author="Claude <noreply@anthropic.com>"`, then `git push`. If the push is rejected because the branch moved, run `git fetch origin <headRefName> && git reset --hard origin/<headRefName>`, redo the insertion + validation on the fresh state, and push once more. If it still fails, go to 7c.
-            - `gh pr edit <number>`: set the title to `Add {N} student events` (N = entries now on the branch) and append to the body one line `- {name} ({category}, {date})` and, on its own plain-text line, `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` — so merging the single PR closes every contributing issue.
-
-            ### 7c — Otherwise (or on any 7b failure), open it
-            - `git checkout -B add-event-pending origin/main`. (On a 7b fallback, use branch `add-event-{id}` and skip the `--label` below — a standalone PR, not the rolling one.)
-            - Insert the entry, validate to green, commit, then `git push -u origin <branch>` (add `--force-with-lease` if the branch already exists from a previously-merged PR).
+            - Commit with `--author="Claude <noreply@anthropic.com>"`, then `git push -u origin add-event-${{ github.event.issue.number || github.event.inputs.issue }}`. This branch is new and unique to this issue — the push should never be rejected; if it somehow is, stop and comment "**Could not open a PR:** {reason}" rather than attempting any reset/force-push recovery.
             - `gh pr create --label pending-events --title "Add 1 student event: {name}"` with a body holding `- {name} ({category}, {date})` and a plain-text `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` line.
-
-            ### 7d — Comment + close
-            Comment on the issue: "Added **{name}** ({category}, {date}) — {why}\n\nPR: {pr_url}". The merge stays a human decision.
+            - Comment on the issue: "Added **{name}** ({category}, {date}) — {why}\n\nPR: {pr_url}". The merge stays a human decision.

--- a/.github/workflows/consolidate-pending.yml
+++ b/.github/workflows/consolidate-pending.yml
@@ -1,0 +1,52 @@
+name: Consolidate Pending Submissions
+
+# Deterministic (no LLM, no claude-code-action) — folds standalone
+# add-benefit-N / add-event-N PRs (opened one-per-issue by add-benefit.yml /
+# add-event.yml) into a single review-ready PR per data file, so the
+# maintainer still reviews one PR instead of one per submission.
+#
+# Replaces the old shared-rolling-branch pattern: that pattern needed a
+# git reset --hard fallback to resolve concurrent-push races, and
+# claude-code-action's headless mode has a built-in, non-configurable
+# restriction on exactly that command shape — which was silently stalling
+# add-benefit/add-event runs (see issue #320). Running the consolidation as
+# plain script logic outside the agent loop sidesteps the restriction
+# entirely: there's no agent here to have permissions denied.
+#
+# Falsifiability (per the "running systems" convention).
+#   Working-when: any run where scripts/consolidate_pending.py finds
+#     candidate PRs completes without error — observable as a PR opened/
+#     updated, or (nothing pending) a clean "Nothing to consolidate" log
+#     line. NOT an output count: most runs will legitimately find nothing.
+#   Teardown after N: 8 consecutive scheduled runs failing (not "finding
+#     nothing" — actually erroring) means the mechanism itself is broken →
+#     revisit before add-benefit/add-event's per-issue PRs pile up unreviewed.
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # every 6 hours
+  workflow_dispatch:
+
+jobs:
+  consolidate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Consolidate pending benefits
+        run: python3 scripts/consolidate_pending.py benefits
+
+      - name: Consolidate pending events
+        run: python3 scripts/consolidate_pending.py events

--- a/.github/workflows/discover-benefits.yml
+++ b/.github/workflows/discover-benefits.yml
@@ -3,14 +3,18 @@ name: Discover Student Benefits
 # Falsifiability (per the "running systems" convention — criterion is contract, cycle history is the Actions run log).
 #   Working-when: each scheduled run COMPLETES and leaves a positive trace of having looked — either ≥1 `new-benefit`
 #     issue opened, OR `agent/state/last-benefits-discovery.json` rewritten with a fresh `timestamp` (the dated "searched,
-#     nothing met the bar" heartbeat). NOT a found-count: silence-by-design (a dry week) is healthy iff the heartbeat moves.
+#     nothing met the bar" heartbeat). NOT a found-count: silence-by-design (a dry cycle) is healthy iff the heartbeat moves.
 #     A run that opens nothing AND doesn't bump the timestamp = the cron silently isn't firing/committing → broken, not empty.
-#   Teardown after N: 8 weekly cycles (~2 months). If working-when is unmet for 8 consecutive Mondays (timestamp never
-#     advances / Actions shows no scheduled runs), the discovery thesis is wrong → remove this workflow. (N is adjustable.)
+#   Teardown after N: 4 biweekly cycles (~2 months — same real-world window as the original 8 weekly cycles). If
+#     working-when is unmet for 4 consecutive scheduled cycles, the discovery thesis is wrong → remove this workflow.
+#   Cadence (2026-08-11 scar): cut from weekly to biweekly. Discovery quality was fine (validated batches came back
+#     legitimate), but throughput was outrunning review capacity — a month of unreviewed backlog piled up before this
+#     was caught. Halving find volume is the fix, not a stricter quality bar. See the redesigned per-issue-PR +
+#     scripts/consolidate_pending.py flow this now feeds into (CLAUDE.md's "Rolling consolidation" section).
 
 on:
   schedule:
-    - cron: '0 14 * * 1'  # Monday 14:00 UTC
+    - cron: '0 14 * * 1'  # Monday 14:00 UTC — gated to even ISO weeks below (biweekly)
   workflow_dispatch:
 
 jobs:
@@ -23,11 +27,24 @@ jobs:
       id-token: write
 
     steps:
+      - name: Check cadence (biweekly — even ISO weeks only; manual runs always proceed)
+        id: cadence
+        run: |
+          week=$(date -u +%V)
+          if [ "${{ github.event_name }}" != "schedule" ] || [ $((10#$week % 2)) -eq 0 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping — ISO week $week is odd, this workflow runs biweekly on even weeks"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.cadence.outputs.run == 'true'
         with:
           fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1
+        if: steps.cadence.outputs.run == 'true'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"

--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -6,12 +6,14 @@ name: Discover Student Events
 #     expiries, nothing actionable" heartbeat). NOT a found-count. A run that bumps the timestamp but never PRs is healthy;
 #     a timestamp that never advances = the cron silently isn't firing → broken, not empty. (Stale events not auto-expiring
 #     is the observable symptom of this being broken.)
-#   Teardown after N: 8 weekly cycles (~2 months). If working-when is unmet for 8 consecutive Wednesdays, the thesis is
-#     wrong → remove this workflow. (N is adjustable.)
+#   Teardown after N: 4 biweekly cycles (~2 months — same real-world window as the original 8 weekly cycles). If
+#     working-when is unmet for 4 consecutive scheduled cycles, the thesis is wrong → remove this workflow.
+#   Cadence (2026-08-11 scar): cut from weekly to biweekly, same reasoning as discover-benefits.yml — find quality was
+#     fine, throughput was outrunning review capacity.
 
 on:
   schedule:
-    - cron: '0 14 * * 3'  # Wednesday 14:00 UTC
+    - cron: '0 14 * * 3'  # Wednesday 14:00 UTC — gated to even ISO weeks below (biweekly)
   workflow_dispatch:
 
 jobs:
@@ -25,11 +27,24 @@ jobs:
       id-token: write
 
     steps:
+      - name: Check cadence (biweekly — even ISO weeks only; manual runs always proceed)
+        id: cadence
+        run: |
+          week=$(date -u +%V)
+          if [ "${{ github.event_name }}" != "schedule" ] || [ $((10#$week % 2)) -eq 0 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping — ISO week $week is odd, this workflow runs biweekly on even weeks"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.cadence.outputs.run == 'true'
         with:
           fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1
+        if: steps.cadence.outputs.run == 'true'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"

--- a/.github/workflows/redispatch-stalled.yml
+++ b/.github/workflows/redispatch-stalled.yml
@@ -1,0 +1,52 @@
+name: Redispatch Stalled Submissions
+
+# Deterministic (no LLM) safety net for add-benefit.yml / add-event.yml runs
+# that silently produce nothing — see scripts/redispatch_stalled.py for the
+# full rationale (issues #267 and #320). Detects the symptom (issue open,
+# labeled, zero comments, past a grace period) and redispatches once via
+# workflow_dispatch; flags for manual review if that doesn't resolve it.
+#
+# Falsifiability (per the "running systems" convention).
+#   Working-when: each scheduled run completes without error — most runs
+#     will legitimately find nothing to redispatch, which is healthy, not
+#     silence. The Actions run log itself is the heartbeat here (no state
+#     file — the mechanism is stateless, tracked entirely via issue labels).
+#   Teardown after N: 8 consecutive scheduled runs erroring (not "finding
+#     nothing") means the mechanism itself is broken.
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # hourly
+  workflow_dispatch:
+
+jobs:
+  redispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+      actions: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Ensure labels exist
+        run: |
+          gh label create redispatched --repo "$GITHUB_REPOSITORY" \
+            --color FBCA04 \
+            --description "add-benefit/add-event redispatched once after appearing stalled" \
+            --force
+          gh label create needs-manual-review --repo "$GITHUB_REPOSITORY" \
+            --color D93F0B \
+            --description "Automatic redispatch didn't resolve this — needs a human to process it directly" \
+            --force
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Sweep and redispatch stalled submissions
+        run: python3 scripts/redispatch_stalled.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,11 +129,13 @@ Each workflow is a plain GitHub Actions YAML in `.github/workflows/`. The agent 
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `add-benefit.yml` | Issue labeled `new-benefit` | Validates + deduplicates, then appends to the rolling `pending-benefits` PR (one PR to review) — standalone PR only as a fallback |
-| `add-event.yml` | Issue labeled `new-event` | Validates against the event quality bar + deduplicates, then appends to the rolling `pending-events` PR — standalone PR only as a fallback |
-| `discover-benefits.yml` | Weekly (Monday) or manual | Searches for new student benefits, opens issues for the best finds |
-| `discover-events.yml` | Weekly (Wednesday) or manual | Searches for notable student events, removes expired entries, opens one PR |
-| `maintain-benefits.yml` | Weekly (Sunday) or manual | Audits link health and quality, fixes findings, opens one PR |
+| `add-benefit.yml` | Issue labeled `new-benefit` | Validates + deduplicates, then opens its own standalone PR (branch `add-benefit-{issue}`) |
+| `add-event.yml` | Issue labeled `new-event` | Validates against the event quality bar + deduplicates, then opens its own standalone PR (branch `add-event-{issue}`) |
+| `consolidate-pending.yml` | Every 6h or manual | Deterministic, no LLM. Folds open standalone `add-benefit-N`/`add-event-N` PRs into one review-ready PR per data file |
+| `redispatch-stalled.yml` | Hourly or manual | Deterministic, no LLM. Safety net: redispatches `add-benefit`/`add-event` runs that produced no comment/PR within 15 min, once; flags `needs-manual-review` if that doesn't resolve it |
+| `discover-benefits.yml` | Biweekly (Monday, even ISO weeks) or manual | Searches for new student benefits, opens issues for the best finds |
+| `discover-events.yml` | Biweekly (Wednesday, even ISO weeks) or manual | Searches for notable student events, removes expired entries, opens one PR |
+| `maintain-benefits.yml` | Weekly (Sunday) or manual | Audits link health and quality, fixes findings, opens one PR (closes any still-open prior `[Maintenance]` PR of its own first) |
 | `validate-data.yml` | PR touching `data/` or the validator | Runs `scripts/validate_data.py` — the deterministic data-integrity gate. |
 | `pr-concierge.yml` | Daily (13:00 UTC) or manual | Sweeps open PRs; once a PR's required checks are green, @-mentions the maintainer (from CODEOWNERS) and labels it `ready-for-review` (idempotent dedup marker). Surfaces Copilot's verdict but gates only on CI; never merges. Deterministic — no LLM. |
 
@@ -143,17 +145,23 @@ When adding a new issue template that introduces a new label, create the GitHub 
 
 No router/orchestrator yet: the two label-triggered workflows (add-benefit, add-event) both fire on any label event and the non-matching one skips correctly. Revisit a dispatcher at 3+ label-triggered workflows.
 
-**Rolling consolidation PRs.** So the maintainer reviews one PR instead of one-per-submission, `add-benefit`/`add-event` append each new entry to a single open PR labelled `pending-benefits` / `pending-events` (branch `add-benefit-pending` / `add-event-pending`) rather than opening a fresh PR each time. Each contributing issue is referenced with its own plain-text `Closes #N`, so the one merge closes them all. It's **best-effort**: on any git/PR failure (e.g. two runs racing the same branch) the workflow falls back to a standalone PR — a submission is never dropped, at worst you get an extra PR. Consolidation never merges anything; the merge stays the human trust boundary.
+**Per-issue PRs, consolidated deterministically** (redesigned 2026-08-11 — see #320). `add-benefit`/`add-event` each open their own standalone PR per issue rather than writing to a shared branch. The prior design (one rolling branch, all runs appending to it) needed a `git reset --hard` fallback to resolve concurrent-push races, and `claude-code-action`'s headless mode has a built-in, non-configurable restriction on force-push/reset-shaped commands — which was silently stalling runs (they'd report `success` while posting no comment and opening no PR) well before any race even occurred. Per-issue branches need no such fallback at all.
+
+`consolidate-pending.yml` (`scripts/consolidate_pending.py`, plain Python — no Claude, no agent-loop restriction to trip) runs every 6 hours and folds every open standalone PR into one review-ready PR per data file, so the maintainer still reviews one PR instead of one-per-submission. It matches candidate PRs structurally (branch name pattern **and** `app/claude` authorship — never by title text, which anyone can set), extracts each one's added entry by diffing against current `main` (robust to `main` having moved since that PR branched), and folds them all into a fresh consolidated branch in one pass. A submission is never silently dropped: an entry that collides (duplicate id) or fails validation once merged leaves its source PR open, unfolded, for manual attention. Consolidation never merges anything; the merge stays the human trust boundary.
+
+`redispatch-stalled.yml` (`scripts/redispatch_stalled.py`) is the companion safety net, covering #267 (a non-collaborator-triggered label event fails the GitHub App token exchange before the agent step even starts — no override exists for this, confirmed against `claude-code-action`'s docs) and any other cause of the same symptom: an `add-benefit`/`add-event` run that leaves its issue open with zero comments past a 15-minute grace period gets redispatched once via `workflow_dispatch` (a write-privileged path, sidestepping the actor-permission gate regardless of who triggered the original label), tracked via the `redispatched` label so it never loops. Still stalled after the retry → `needs-manual-review` label + one comment, then left alone.
 
 ### Falsifiability (scheduled workflows)
 
-Every cron workflow carries, in its YAML, a **working-when** criterion + an **N-cycle teardown** clause (the "running systems" convention). **Criteria are contract** (in the files); **cycle history is state** (the Actions run log) — don't restate run history here. The criteria are silence-tolerant by design: these are discovery/maintenance surfacers that *may legitimately find nothing* some weeks, so the test is **the pipeline being alive**, never an output count. Working-when = a scheduled run *completes and leaves a positive trace of having looked* (an issue/PR, or a dated heartbeat in its state file). Default N = **8 weekly cycles (~2 months)**, adjustable per workflow.
+Every cron workflow carries, in its YAML, a **working-when** criterion + an **N-cycle teardown** clause (the "running systems" convention). **Criteria are contract** (in the files); **cycle history is state** (the Actions run log) — don't restate run history here. The criteria are silence-tolerant by design: these are discovery/maintenance surfacers that *may legitimately find nothing* some cycles, so the test is **the pipeline being alive**, never an output count. Working-when = a scheduled run *completes and leaves a positive trace of having looked* (an issue/PR, or a dated heartbeat in its state file). Default N = **8 cycles at that workflow's own cadence** — total elapsed time varies (biweekly workflows use N=4 for the same ~2-month window; the two deterministic hourly/6h mechanisms are pure plumbing with no content-volume signal, so their N is about the mechanism erroring, not finding nothing).
 
 | Workflow | Working-when (positive trace) | N |
 |---|---|---|
-| `discover-benefits` | `new-benefit` issue opened **or** `last-benefits-discovery.json` timestamp bumped | 8 wk |
-| `discover-events` | PR opened **or** `last-events-discovery.json` timestamp bumped | 8 wk |
+| `discover-benefits` | `new-benefit` issue opened **or** `last-benefits-discovery.json` timestamp bumped | 4 biwk |
+| `discover-events` | PR opened **or** `last-events-discovery.json` timestamp bumped | 4 biwk |
 | `maintain-benefits` | `[Maintenance]` PR **or** `link-health` issues closed with outcome; else green scheduled run in Actions log | 8 wk |
+| `consolidate-pending` | Green scheduled run in Actions log (most runs legitimately find nothing to fold) | 8 × 6h |
+| `redispatch-stalled` | Green scheduled run in Actions log (most runs legitimately find nothing stalled) | 8 × 1h |
 
 **The criterion's FIRST job is catching a cron that silently isn't running** — not weak output. Verify each working-when against the live Actions run history before trusting any "stays current automatically" claim; a missing/stale state file is the alarm, not noise. (Scar 2026-08-11: two different failure shapes hid behind the same symptom. `last-benefits-discovery.json` sat 2 months stale — not because the cron wasn't firing, but because its PRs weren't being merged, masking a real backlog. `reddit-state.json` was stuck since March for a genuine reason — `scout-reddit.yml`'s commit step ran after `claude-code-action` revoked its own push token, so every scheduled run hard-failed for 10 straight weeks. Diagnosed and removed rather than fixed, since it had never produced a usable find in that time. Lesson: a stale heartbeat means "go find out why," not "assume the obvious cause.")
 

--- a/scripts/consolidate_pending.py
+++ b/scripts/consolidate_pending.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Deterministically consolidate standalone add-benefit-N / add-event-N PRs
+into one review-ready PR, without an LLM in the loop.
+
+add-benefit.yml / add-event.yml each open their own standalone PR per issue
+(never a shared branch — see CLAUDE.md's "Rolling consolidation" section for
+why: claude-code-action's headless mode has a built-in, non-configurable
+restriction on force-push/reset-shaped commands, and a shared branch needs
+exactly that to resolve concurrent-push races). This script is the plain,
+non-agentic step that does the consolidation instead: read each open
+candidate PR, extract the one entry it adds (by set-difference against
+current main, robust to main having moved since that PR branched), fold all
+of them into current main in one pass, and push a single consolidated PR.
+
+Run with no side effects beyond git/gh calls already scoped by the calling
+workflow's permissions. Safe to run repeatedly — a run with nothing new to
+fold in is a no-op.
+
+Usage: python3 scripts/consolidate_pending.py <benefits|events>
+"""
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+MODES = {
+    "benefits": dict(
+        data_file="data/benefits.json",
+        branch_re=re.compile(r"^add-benefit-(\d+)$"),
+        consolidated_branch="pending-benefits-consolidated",
+        label="pending-benefits",
+        sort_key=lambda e: e["id"],
+        item_line=lambda e: f"- {e['name']} ({e['category']})",
+        pr_title="Add {n} student benefit{s}",
+    ),
+    "events": dict(
+        data_file="data/events.json",
+        branch_re=re.compile(r"^add-event-(\d+)$"),
+        consolidated_branch="pending-events-consolidated",
+        label="pending-events",
+        sort_key=lambda e: e["date"],
+        item_line=lambda e: f"- {e['name']} ({e['category']}, {e['date']})",
+        pr_title="Add {n} student event{s}",
+    ),
+}
+
+
+def run(cmd, **kwargs):
+    kwargs.setdefault("cwd", ROOT)
+    kwargs.setdefault("check", True)
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+    return subprocess.run(cmd, **kwargs)
+
+
+def run_ok(cmd, **kwargs):
+    kwargs["check"] = False
+    return run(cmd, **kwargs)
+
+
+def load_json_at_ref(ref: str, path: str):
+    r = run_ok(["git", "show", f"{ref}:{path}"])
+    if r.returncode != 0:
+        return None
+    return json.loads(r.stdout)
+
+
+def write_json(path: Path, data) -> None:
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def gh_json(args):
+    r = run(["gh"] + args)
+    return json.loads(r.stdout)
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or sys.argv[1] not in MODES:
+        print(f"usage: {sys.argv[0]} <{'|'.join(MODES)}>", file=sys.stderr)
+        return 2
+    mode = MODES[sys.argv[1]]
+    data_path = ROOT / mode["data_file"]
+
+    run(["git", "fetch", "origin", "main"])
+    main_data = load_json_at_ref("origin/main", mode["data_file"])
+    main_ids = {e["id"] for e in main_data}
+
+    prs = gh_json(["pr", "list", "--state", "open", "--json",
+                    "number,headRefName,author", "--limit", "100"])
+
+    candidates = []  # (pr_number, issue_number, entry)
+    skipped_stale = []  # PRs whose branch added nothing new (already superseded)
+    for pr in prs:
+        m = mode["branch_re"].match(pr["headRefName"])
+        # Both checks matter: branch name alone is a PR author's free choice,
+        # not proof this PR came from add-benefit.yml/add-event.yml.
+        if not m or pr["author"]["login"] != "app/claude":
+            continue
+        issue_number = int(m.group(1))
+        run(["git", "fetch", "origin", pr["headRefName"]])
+        branch_data = load_json_at_ref("FETCH_HEAD", mode["data_file"])
+        if branch_data is None:
+            continue
+        branch_ids = {e["id"] for e in branch_data}
+        new_ids = branch_ids - main_ids
+        if not new_ids:
+            skipped_stale.append(pr["number"])
+            continue
+        by_id = {e["id"]: e for e in branch_data}
+        for nid in new_ids:
+            candidates.append((pr["number"], issue_number, by_id[nid]))
+
+    if not candidates and not skipped_stale:
+        print("Nothing to consolidate.")
+        return 0
+
+    # Build the consolidated branch fresh off current main.
+    run(["git", "checkout", "-B", mode["consolidated_branch"], "origin/main"])
+    write_json(data_path, main_data)
+
+    included = []   # (pr_number, issue_number, entry)
+    duplicate = []  # (pr_number, issue_number, entry) — id collided, needs a human
+    working = {e["id"]: e for e in main_data}
+
+    for pr_number, issue_number, entry in candidates:
+        if entry["id"] in working:
+            duplicate.append((pr_number, issue_number, entry))
+            continue
+        working[entry["id"]] = entry
+        merged = sorted(working.values(), key=mode["sort_key"])
+        write_json(data_path, merged)
+        v = run_ok(["python3", "scripts/validate_data.py"])
+        if v.returncode != 0:
+            # This entry alone doesn't validate against the merged state —
+            # back it out, leave its source PR open for manual attention.
+            del working[entry["id"]]
+            merged = sorted(working.values(), key=mode["sort_key"])
+            write_json(data_path, merged)
+            duplicate.append((pr_number, issue_number, entry))
+            continue
+        included.append((pr_number, issue_number, entry))
+
+    if not included:
+        print("Nothing validated cleanly; nothing to push.")
+        run(["git", "checkout", "-"])
+        return 0
+
+    run(["git", "add", mode["data_file"]])
+    diff = run_ok(["git", "diff", "--cached", "--quiet"])
+    if diff.returncode == 0:
+        print("No diff against main after merge — nothing to push.")
+        return 0
+
+    n = len(included)
+    run(["git", "-c", "user.name=Claude", "-c", "user.email=noreply@anthropic.com",
+         "commit", "-m", f"Consolidate {n} pending {sys.argv[1]}"])
+    run(["git", "push", "--force-with-lease", "-u", "origin", mode["consolidated_branch"]])
+
+    body_lines = [mode["item_line"](e) for _, _, e in included]
+    closes_lines = [f"Closes #{issue_number}" for _, issue_number, _ in included]
+    body = "\n".join(body_lines) + "\n\n" + "\n".join(closes_lines)
+    title = mode["pr_title"].format(n=n, s="" if n == 1 else "s")
+
+    existing = gh_json(["pr", "list", "--state", "open", "--head",
+                         mode["consolidated_branch"], "--json", "number"])
+    if existing:
+        pr_number = existing[0]["number"]
+        run(["gh", "pr", "edit", str(pr_number), "--title", title, "--body", body])
+    else:
+        r = run(["gh", "pr", "create", "--base", "main", "--label", mode["label"],
+                  "--title", title, "--body", body, "--head", mode["consolidated_branch"]])
+        pr_number = int(r.stdout.strip().rstrip("/").rsplit("/", 1)[-1])
+
+    for src_pr, issue_number, entry in included:
+        run_ok(["gh", "pr", "close", str(src_pr), "--comment",
+                f"Folded into #{pr_number}."])
+
+    for src_pr in skipped_stale:
+        run_ok(["gh", "pr", "close", str(src_pr), "--comment",
+                "Superseded — this entry is already on main."])
+
+    for src_pr, issue_number, entry in duplicate:
+        print(f"PR #{src_pr} (issue #{issue_number}, id={entry['id']!r}) "
+              f"needs manual attention — id collision or validation failure.")
+
+    print(f"Consolidated {n} {sys.argv[1]} into PR #{pr_number}. "
+          f"{len(duplicate)} need manual attention. {len(skipped_stale)} already stale.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/redispatch_stalled.py
+++ b/scripts/redispatch_stalled.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Safety net for add-benefit.yml / add-event.yml runs that silently produce
+nothing — either issue #267 (the triggering actor lacks write access, so
+claude-code-action's app-token exchange 401s before the agent step even
+starts) or any other cause (see #320).
+
+Detects the OBSERVABLE SYMPTOM — issue still open, still labeled, zero
+comments, past a grace period — rather than the specific root cause, and
+redispatches via `gh workflow run` (workflow_dispatch), a write-privileged
+path that sidesteps #267's actor-permission gate regardless of who
+originally triggered the label event.
+
+Three states per issue, tracked via labels so this never spams or loops:
+  no `redispatched` label            -> redispatch once, add the label
+  `redispatched`, no `needs-manual-review` -> still stalled after a retry;
+                                              comment once, add that label
+  `needs-manual-review` present      -> already flagged, leave it alone
+
+Usage: python3 scripts/redispatch_stalled.py
+"""
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+GRACE_MINUTES = 15
+
+TARGETS = [
+    ("new-benefit", "add-benefit.yml"),
+    ("new-event", "add-event.yml"),
+]
+
+
+def run(cmd, **kwargs):
+    kwargs.setdefault("check", True)
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+    return subprocess.run(cmd, **kwargs)
+
+
+def run_ok(cmd, **kwargs):
+    kwargs["check"] = False
+    return run(cmd, **kwargs)
+
+
+def main() -> int:
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=GRACE_MINUTES)
+
+    for label, workflow in TARGETS:
+        r = run(["gh", "issue", "list", "--state", "open", "--label", label,
+                 "--json", "number,createdAt,comments,labels", "--limit", "100"])
+        issues = json.loads(r.stdout)
+
+        for issue in issues:
+            created = datetime.fromisoformat(issue["createdAt"].replace("Z", "+00:00"))
+            if created >= cutoff or issue["comments"]:
+                continue  # too fresh to judge, or the bot already responded
+
+            num = issue["number"]
+            issue_labels = {l["name"] for l in issue["labels"]}
+
+            if "needs-manual-review" in issue_labels:
+                continue  # already flagged, don't repeat
+
+            if "redispatched" in issue_labels:
+                print(f"#{num}: still stalled after a retry — flagging for manual review")
+                run_ok(["gh", "issue", "comment", str(num), "--body",
+                        "Automatic redispatch didn't resolve this — this submission needs "
+                        "manual attention. Known failure modes: #267 (external submitter, "
+                        "GitHub App token exchange requires write access) or #320 "
+                        f"(internal permission-denial stall). Process directly with "
+                        f"`gh workflow run {workflow} -f issue={num}`."])
+                run_ok(["gh", "issue", "edit", str(num), "--add-label", "needs-manual-review"])
+                continue
+
+            print(f"#{num}: stalled, no prior redispatch — redispatching via {workflow}")
+            labeled = run_ok(["gh", "issue", "edit", str(num), "--add-label", "redispatched"])
+            if labeled.returncode != 0:
+                print(f"  warn: could not label #{num} — skipping redispatch this cycle")
+                continue
+            dispatched = run_ok(["gh", "workflow", "run", workflow, "-f", f"issue={num}"])
+            if dispatched.returncode != 0:
+                print(f"  warn: could not redispatch #{num}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes #267 and #320 together — both trace to the same design flaw. `add-benefit.yml`/`add-event.yml` wrote to a shared rolling branch, which needed a `git reset --hard` fallback to resolve concurrent-push races. `claude-code-action`'s headless mode has a built-in, non-configurable restriction on force-push/reset-shaped commands (confirmed against its own docs), and hitting it silently stalled runs — they'd report `success` while posting no comment and opening no PR. 7 of 8 recent `add-benefit` runs on genuinely good candidates did exactly this before being caught and manually shipped in #316.

## Changes

**`add-benefit.yml` / `add-event.yml`** — each run now opens its own standalone PR on a unique per-issue branch (`add-benefit-{issue}` / `add-event-{issue}`). No shared branch, no race, no reset/force-push ever needed.

**`consolidate-pending.yml`** + `scripts/consolidate_pending.py` (new) — deterministic (no Claude), runs every 6 hours, folds all open standalone PRs into one review-ready PR per data file, so the maintainer still reviews one PR instead of one-per-submission. Matches candidates structurally (branch pattern **and** `app/claude` authorship — never by title text, which anyone can set) and extracts each one's entry by diffing against current `main` (robust to `main` having moved since that PR branched). Never silently drops a submission: id collisions or post-merge validation failures leave the source PR open, unfolded, for manual attention.

**`redispatch-stalled.yml`** + `scripts/redispatch_stalled.py` (new) — deterministic hourly safety net covering #267 directly: an issue left open with zero comments past a 15-minute grace period gets redispatched once via `workflow_dispatch` (a write-privileged path, sidesteps the actor-permission gate regardless of who triggered the label), tracked via the `redispatched` label so it never loops. Still stalled after that → `needs-manual-review` label + one comment, then left alone.

**`discover-benefits.yml` / `discover-events.yml`** — cut from weekly to biweekly (ISO-week-parity gate on scheduled runs only; manual `workflow_dispatch` always proceeds). Quality was fine — every submission validated today came back legitimate — throughput was outrunning review capacity. Halves volume rather than tightening the quality bar.

**`CLAUDE.md`** — rewrote the "Rolling consolidation PRs" section and the workflow/falsifiability tables for the new architecture.

## Testing done
- All new/changed YAML validated for syntax
- `scripts/consolidate_pending.py` and `scripts/redispatch_stalled.py` run locally against the live repo (currently nothing pending/stalled) — confirmed clean no-op paths, exit 0, no unintended git/gh side effects
- Traced the consolidation merge logic by hand through the happy path, an id-collision race, and a validation-failure backout — all three correctly isolate to the one bad entry without discarding the rest of the batch
- **Not yet done**: a live end-to-end run against a real issue (needs this to merge first, then a manual `workflow_dispatch` test — will do as a follow-up and report back)

## Not in scope
Doesn't touch `maintain-benefits.yml`'s cadence (weekly, unchanged) — its job is upkeep of existing entries, not open-ended new content, and its own stale-PR-supersede fix (merged in #319) already bounds its review burden to one PR at a time.