### PR TITLE
Fix 5 audit findings: dead state writes, notification leak, CI gap, stale pointers

### DIFF
--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -62,11 +62,15 @@ jobs:
 
             **Build & grow (the curation thesis):** the benefit must help a student *create, learn, ship, or research* — dev tools, infrastructure, cloud/AI credits, design and learning platforms, the hardware students build on. Reject consumption perks regardless of how good the deal is: entertainment (music, video streaming), shopping, consumer subscriptions (e.g. a consumer VPN), and broad discount aggregators (Student Beans / UNiDAYS-style). The test isn't "is this a real student discount?" but "does this advance building or learning?" — if it doesn't, it's a reject even when the offer is genuine and well-priced.
 
-            If invalid, comment "**Cannot add:** {reason}". Then append to `agent/state/rejected.json`:
+            If invalid, comment "**Cannot add:** {reason}". Then append to `agent/state/rejected.json` and commit it (see "Committing `rejected.json`" below):
             ```json
             { "name": "{name}", "domain": "{hostname or null}", "reason": "{reason}", "checked": "{YYYY-MM-DD}" }
             ```
             Close the issue and stop.
+
+            ### Committing `rejected.json`
+
+            This file is internal state, not public data — commit and push it directly to `main`, no PR needed: `git add agent/state/rejected.json && git commit --author="Claude <noreply@anthropic.com>" -m "Reject {name}" && git push origin HEAD:main`. Do this every time you append to it, from either Step 3 or Step 4.5 — a rejection that's never committed can't be deduplicated against next time, defeating the point of keeping this file.
 
             ## Step 4: Generate the entry
 
@@ -99,7 +103,7 @@ jobs:
 
             1. `WebFetch` your chosen `link`. A real page must load — not a 404, "page not found", or error page. Treat a redirect's final URL as the real link and use that.
             2. If it does not load: `WebSearch` for the program's actual student signup/education page, `WebFetch` the top candidate, and use the URL that genuinely loads. Copy it **verbatim** — do not edit the path by hand.
-            3. If no working student-program URL loads after this, the program isn't addable: comment "**Cannot add:** could not confirm a live student signup page", append to `rejected.json` (Step 3 format), close the issue, and stop.
+            3. If no working student-program URL loads after this, the program isn't addable: comment "**Cannot add:** could not confirm a live student signup page", append to `rejected.json` and commit it (Step 3 format and commit instructions), close the issue, and stop.
 
             This applies even when the user supplied the link — a submitted URL is a candidate, not a verified one.
 
@@ -135,5 +139,5 @@ jobs:
             - Insert the entry into `data/benefits.json` in its `id`-sorted position (per Step 5), and replace `agent/state/last-run.json` (per Step 5).
             - Run `python3 scripts/validate_data.py` until it exits 0.
             - Commit with `--author="Claude <noreply@anthropic.com>"`, then `git push -u origin add-benefit-${{ github.event.issue.number || github.event.inputs.issue }}`. This branch is new and unique to this issue — the push should never be rejected; if it somehow is, stop and comment "**Could not open a PR:** {reason}" rather than attempting any reset/force-push recovery.
-            - `gh pr create --label pending-benefits --title "Add 1 student benefit: {name}"` with a body holding `- {name} ({category})` and a plain-text `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` line.
+            - `gh pr create --title "Add 1 student benefit: {name}"` (no label — `consolidate-pending.yml` matches candidate PRs by branch name and author, not by label; the `pending-benefits` label is reserved for the consolidated PR) with a body holding `- {name} ({category})` and a plain-text `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` line.
             - Comment on the issue: "Added **{name}** ({category}) — {description}\n\nPR: {pr_url}". The merge stays a human decision.

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -111,5 +111,5 @@ jobs:
             - Insert the entry into `data/events.json` in date order (earliest first), per Step 6, and replace `agent/state/last-events-submission.json` per Step 6.
             - Run `python3 scripts/validate_data.py` until it exits 0.
             - Commit with `--author="Claude <noreply@anthropic.com>"`, then `git push -u origin add-event-${{ github.event.issue.number || github.event.inputs.issue }}`. This branch is new and unique to this issue — the push should never be rejected; if it somehow is, stop and comment "**Could not open a PR:** {reason}" rather than attempting any reset/force-push recovery.
-            - `gh pr create --label pending-events --title "Add 1 student event: {name}"` with a body holding `- {name} ({category}, {date})` and a plain-text `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` line.
+            - `gh pr create --title "Add 1 student event: {name}"` (no label — `consolidate-pending.yml` matches candidate PRs by branch name and author, not by label; the `pending-events` label is reserved for the consolidated PR) with a body holding `- {name} ({category}, {date})` and a plain-text `Closes #${{ github.event.issue.number || github.event.inputs.issue }}` line.
             - Comment on the issue: "Added **{name}** ({category}, {date}) — {why}\n\nPR: {pr_url}". The merge stays a human decision.

--- a/.github/workflows/discover-benefits.yml
+++ b/.github/workflows/discover-benefits.yml
@@ -10,7 +10,7 @@ name: Discover Student Benefits
 #   Cadence (2026-08-11 scar): cut from weekly to biweekly. Discovery quality was fine (validated batches came back
 #     legitimate), but throughput was outrunning review capacity — a month of unreviewed backlog piled up before this
 #     was caught. Halving find volume is the fix, not a stricter quality bar. See the redesigned per-issue-PR +
-#     scripts/consolidate_pending.py flow this now feeds into (CLAUDE.md's "Rolling consolidation" section).
+#     scripts/consolidate_pending.py flow this now feeds into (CLAUDE.md's "Per-issue PRs, consolidated deterministically" section).
 
 on:
   schedule:
@@ -132,3 +132,5 @@ jobs:
               "issues_created": <number>
             }
             ```
+
+            This is the heartbeat this workflow's working-when criterion depends on — commit and push it directly to `main`, no PR needed (it's internal state, not public data): `git add agent/state/last-benefits-discovery.json && git commit --author="Claude <noreply@anthropic.com>" -m "Update benefits discovery log" && git push origin HEAD:main`. Do this every run, whether or not you opened any issues — a run that finds nothing is still a healthy heartbeat as long as this file moves.

--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -109,7 +109,7 @@ jobs:
 
             Then run `python3 scripts/validate_data.py` and fix `data/events.json` until it exits 0 before opening the PR — never open it while the validator is red. It is the deterministic gate for schema, link shape, and date order, so let it catch what you missed instead of guessing.
 
-            **Branch**: `discover-events-{YYYY-MM-DD}` (today's date) — never reuse or invent another name; this keeps each week's run on its own branch so runs never race each other.
+            **Branch**: `discover-events-{YYYY-MM-DD}` (today's date) — never reuse or invent another name; this keeps each run on its own branch so runs never race each other.
 
             **Title**: `[Events]: <comma-separated new event names>` (or `Expire stale entries` if only removing)
 

--- a/.github/workflows/pr-concierge.yml
+++ b/.github/workflows/pr-concierge.yml
@@ -6,6 +6,19 @@ name: PR Concierge
 # Copilot) is surfaced in the comment for context but does NOT gate the ping —
 # CI is the only gate. Deterministic: no LLM, no token cost. The merge itself
 # stays a human decision (the trust boundary).
+#
+# Excludes add-benefit-N / add-event-N branches: those are transient per-issue
+# PRs meant to be folded by consolidate-pending.yml (every 6h) before a human
+# ever needs to look at them individually — pinging on one defeats the point of
+# that consolidation.
+#
+# Falsifiability (per the "running systems" convention).
+#   Working-when: each scheduled run completes without error — most days will
+#     legitimately have nothing newly ready, which is healthy, not silence. The
+#     Actions run log is the heartbeat (no state file — purely deterministic,
+#     nothing to persist between runs beyond the labels already on each PR).
+#   Teardown after N: 8 consecutive scheduled runs erroring (not "finding
+#     nothing ready") means the mechanism itself is broken.
 
 on:
   schedule:
@@ -57,7 +70,7 @@ jobs:
           # not a block. Copilot's verdict is surfaced for context but never gates
           # the ping (it sometimes errors), so a green PR is never stuck on it.
           ready=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 200 \
-            --json number,title,isDraft,author,labels,statusCheckRollup,reviews \
+            --json number,title,isDraft,author,labels,statusCheckRollup,reviews,headRefName \
             | jq -c --arg owner "$owner" '
               def copilot:
                 ([.reviews[]? | select(.author.login=="copilot-pull-request-reviewer")] | last);
@@ -77,6 +90,7 @@ jobs:
               | select(.isDraft | not)
               | select(.author.login != $owner)
               | select([.labels[]?.name] | index("ready-for-review") | not)
+              | select(.headRefName | test("^add-(benefit|event)-[0-9]+$") | not)
               | { number, title, ci: ci,
                   cilabel: (if ((.statusCheckRollup // []) | length) == 0
                             then "no CI checks" else "checks ✓" end),

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -3,15 +3,13 @@ name: Validate Data
 on:
   pull_request:
     paths:
-      - 'data/benefits.json'
-      - 'data/events.json'
-      - 'data/categories.json'
+      - 'data/**'
       - 'scripts/validate_data.py'
   push:
     branches: [main]
     paths:
-      - 'data/benefits.json'
-      - 'data/events.json'
+      - 'data/**'
+      - 'scripts/validate_data.py'
   workflow_dispatch:
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,8 @@ well-priced consumer VPN or music subscription is still a reject.
 truth, never hardcoded in HTML.
 
 **Active discovery, not passive curation.** Content enters through multiple
-paths: humans submit issues (pull); `discover-benefits` searches the web weekly
-for new student programs (push); `discover-events` finds upcoming student events
+paths: humans submit issues (pull); `discover-benefits` searches the web
+biweekly for new student programs (push); `discover-events` finds upcoming student events
 and removes expired ones automatically (push + self-maintenance). The system
 surfaces what people haven't thought to add and keeps itself current.
 
@@ -162,6 +162,7 @@ Every cron workflow carries, in its YAML, a **working-when** criterion + an **N-
 | `maintain-benefits` | `[Maintenance]` PR **or** `link-health` issues closed with outcome; else green scheduled run in Actions log | 8 wk |
 | `consolidate-pending` | Green scheduled run in Actions log (most runs legitimately find nothing to fold) | 8 × 6h |
 | `redispatch-stalled` | Green scheduled run in Actions log (most runs legitimately find nothing stalled) | 8 × 1h |
+| `pr-concierge` | Green scheduled run in Actions log (most days legitimately find nothing newly ready) | 8 × 1d |
 
 **The criterion's FIRST job is catching a cron that silently isn't running** — not weak output. Verify each working-when against the live Actions run history before trusting any "stays current automatically" claim; a missing/stale state file is the alarm, not noise. (Scar 2026-08-11: two different failure shapes hid behind the same symptom. `last-benefits-discovery.json` sat 2 months stale — not because the cron wasn't firing, but because its PRs weren't being merged, masking a real backlog. `reddit-state.json` was stuck since March for a genuine reason — `scout-reddit.yml`'s commit step ran after `claude-code-action` revoked its own push token, so every scheduled run hard-failed for 10 straight weeks. Diagnosed and removed rather than fixed, since it had never produced a usable find in that time. Lesson: a stale heartbeat means "go find out why," not "assume the obvious cause.")
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Grant — an agentic system powered by Claude — curates a directory of student benefits that help you build, learn, and ship.**
 
-Grant is a set of workflows, a deterministic validation gate, and a human who merges — not one autonomous agent. It discovers new programs each week, validates community submissions opened as issues, and audits link health. Every change is checked by the gate and approved by a person before it goes live — the merge is the trust boundary. Run logs and tool traces are open. **[→ student-benefits.github.io](https://student-benefits.github.io)**
+Grant is a set of workflows, a deterministic validation gate, and a human who merges — not one autonomous agent. It discovers new programs on a biweekly cadence, validates community submissions opened as issues, and audits link health. Every change is checked by the gate and approved by a person before it goes live — the merge is the trust boundary. Run logs and tool traces are open. **[→ student-benefits.github.io](https://student-benefits.github.io)**
 
 [![Live](https://img.shields.io/badge/live-student--benefits.github.io-blue)](https://student-benefits.github.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)

--- a/scripts/consolidate_pending.py
+++ b/scripts/consolidate_pending.py
@@ -3,10 +3,11 @@
 into one review-ready PR, without an LLM in the loop.
 
 add-benefit.yml / add-event.yml each open their own standalone PR per issue
-(never a shared branch — see CLAUDE.md's "Rolling consolidation" section for
-why: claude-code-action's headless mode has a built-in, non-configurable
-restriction on force-push/reset-shaped commands, and a shared branch needs
-exactly that to resolve concurrent-push races). This script is the plain,
+(never a shared branch — see CLAUDE.md's "Per-issue PRs, consolidated
+deterministically" section for why: claude-code-action's headless mode has
+a built-in, non-configurable restriction on force-push/reset-shaped
+commands, and a shared branch needs exactly that to resolve concurrent-push
+races). This script is the plain,
 non-agentic step that does the consolidation instead: read each open
 candidate PR, extract the one entry it adds (by set-difference against
 current main, robust to main having moved since that PR branched), fold all


### PR DESCRIPTION
## Summary

Audit findings A1, A2, C, D3, B1-B4.

**A1** — `add-benefit.yml`'s reject path appended to `rejected.json` then closed the issue without ever committing; the write died with the runner. `rejected.json` has been `[]` since May as a result — three prompt sites depend on it and it has never once fired. Now commits directly to `main` (internal state, no PR needed) from both reject paths (Step 3 and Step 4.5).

**A2** — `discover-benefits.yml` has never had a commit step for its own heartbeat file, in any historical version I checked. Its working-when criterion in CLAUDE.md was structurally unmeetable via that branch. Fixed the same way as A1.

**C** — `pr-concierge.yml` wasn't updated for today's per-issue-PR redesign: it would @-mention about individual `add-benefit-N`/`add-event-N` PRs before `consolidate-pending.yml` (every 6h) gets a chance to fold them, undermining the whole point of that redesign. Added a branch-pattern exclusion (tested against synthetic data). Also added its missing falsifiability clause and CLAUDE.md table row (it was the only cron workflow without one).

**D3** — `validate-data.yml`'s path filters missed `data/event-categories.json` entirely (read by the validator, so a PR breaking event categories could slip past the gate), and the `push` trigger was narrower still. Broadened both triggers to `data/**` + the validator script.

**B1-B4** — `pending-benefits`/`pending-events` label descriptions still described the deleted shared-branch mechanism; dropped `--label` from individual per-issue PR creation (consolidation already matches by branch+author, never used the label) and reserved it for the consolidated PR only. Fixed 2 stale citations to CLAUDE.md's renamed section. Fixed 3 leftover "weekly" references left behind by the biweekly cadence cut.

## Test plan
- [x] All touched YAML validated for syntax
- [x] `scripts/consolidate_pending.py` still compiles
- [x] `python3 scripts/validate_data.py` passes
- [x] pr-concierge's new jq filter tested against synthetic data — correctly excludes an `add-benefit-312` branch while passing through a consolidated-PR branch