### PR TITLE
Render the repo field instead of leaving it unused

### DIFF
--- a/benefits/index.css
+++ b/benefits/index.css
@@ -255,14 +255,32 @@
   line-height: 1.5;
 }
 
+.card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
 .tags {
   display: flex;
   flex-wrap: wrap;
   gap: 0.375rem;
-  margin-top: 0.75rem;
   position: relative;
   z-index: 1;
 }
+
+.repo-link {
+  flex-shrink: 0;
+  display: inline-flex;
+  color: var(--slate-500);
+  position: relative;
+  z-index: 1;
+  transition: color var(--dur-normal);
+}
+.repo-link:hover { color: var(--indigo-300); }
+.repo-link svg { width: 16px; height: 16px; }
 
 .tag {
   font-size: 0.75rem;

--- a/benefits/index.js
+++ b/benefits/index.js
@@ -40,6 +40,11 @@ function renderCard(b) {
   const pill = b.offer_type
     ? `<span class="offer-pill offer-${b.offer_type}">${OFFER_LABELS[b.offer_type]}</span>`
     : '';
+  const repoLink = b.repo
+    ? `<a class="repo-link" href="https://github.com/${escapeHtml(b.repo)}" target="_blank" rel="noopener noreferrer" title="Open source: ${escapeHtml(b.repo)}">
+        <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+      </a>`
+    : '';
   return `<article class="card">
     <div class="card-body">
       <a class="card-link" href="${escapeHtml(b.link)}" target="_blank" rel="noopener noreferrer">
@@ -50,7 +55,10 @@ function renderCard(b) {
         <h3 class="card-name">${escapeHtml(b.name)}</h3>
         <p class="card-desc">${escapeHtml(b.description)}</p>
       </a>
-      <div class="tags">${tags}</div>
+      <div class="card-footer">
+        <div class="tags">${tags}</div>
+        ${repoLink}
+      </div>
     </div>
   </article>`;
 }


### PR DESCRIPTION
## Summary

5 benefit entries (`jetbrains-ides`, `mongodb-atlas`, `obsidian`, `weights-and-biases`, `zed`) carry a documented `repo` field (CLAUDE.md: "optional; only for open-source projects") that rendered nowhere — real curator-added data with no UI. Added a small GitHub icon link on cards that have it.

## Test plan
- [x] `document.querySelectorAll('.repo-link').length` → 5, matching the 5 entries with the field
- [x] Visually confirmed on JetBrains IDEs and Obsidian cards (screenshot verified)
- [x] Zero console errors