### PR TITLE
Front-end simplification: date range bug fix, style-injection removal, path consistency

### DIFF
--- a/agent/agent.js
+++ b/agent/agent.js
@@ -237,7 +237,7 @@ function addSimStep(step, trace, btn) {
 
 document.getElementById('sim-btn').addEventListener('click', simNext);
 
-fetch('../data/benefits.json')
+fetch('/data/benefits.json')
   .then(r => r.ok ? r.json() : [])
   .then(data => { SIM_STEPS[1].primary = data.length + ' existing benefits loaded. Checking for name and hostname matches…'; })
   .catch(() => {});

--- a/agent/index.html
+++ b/agent/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#f5f5f0">
   <meta name="description" content="Grant curates Student Benefits Hub with Claude — an agentic system built from workflows, a deterministic gate, and a human in the loop. See the loop, in the field's own terms.">
-  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
   <title>Grant · How the loop works · Student Benefits Hub</title>
   <link rel="stylesheet" href="/agent/agent.css">
 </head>

--- a/benefits/index.css
+++ b/benefits/index.css
@@ -182,8 +182,6 @@
   user-select: none;
 }
 
-/* Category badge colors injected dynamically from data/categories.json at load time */
-
 .offer-pill {
   display: inline-flex;
   align-items: center;

--- a/benefits/index.js
+++ b/benefits/index.js
@@ -44,7 +44,7 @@ function renderCard(b) {
     <div class="card-body">
       <a class="card-link" href="${escapeHtml(b.link)}" target="_blank" rel="noopener noreferrer">
         <div class="card-top">
-          <span class="badge" data-cat="${escapeHtml(b.category)}">${escapeHtml(b.category)}</span>
+          <span class="badge" style="color:${catColor(b.category)}">${escapeHtml(b.category)}</span>
           ${pill}
         </div>
         <h3 class="card-name">${escapeHtml(b.name)}</h3>
@@ -149,11 +149,6 @@ Promise.all([
 ]).then(function (results) {
   benefits = results[0];
   categories = ['All'].concat(results[1]);
-  const sheet = document.createElement('style');
-  sheet.textContent = results[1].map(function (cat) {
-    return `.badge[data-cat="${cat.replace(/"/g, '\\"')}"] { color: ${catColor(cat)}; }`;
-  }).join('\n');
-  document.head.appendChild(sheet);
   renderFilters();
   render();
 }).catch(function () {

--- a/events/events.js
+++ b/events/events.js
@@ -19,19 +19,14 @@ const categoryTooltips = {
 
 function orgColor(name) { return hashColor(name, ORG_PALETTE); }
 
+const DATE_RANGE_FMT = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
 function fmtDate(date, dateEnd) {
-  const opts = { month: 'short', day: 'numeric', year: 'numeric' };
   const start = new Date(date + 'T12:00:00');
   if (!dateEnd || dateEnd === date) {
-    return start.toLocaleDateString('en-US', opts);
+    return DATE_RANGE_FMT.format(start);
   }
-  const end = new Date(dateEnd + 'T12:00:00');
-  if (start.getFullYear() === end.getFullYear() && start.getMonth() === end.getMonth()) {
-    return start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) +
-      '–' + end.getDate() + ', ' + end.getFullYear();
-  }
-  return start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) +
-    ' – ' + end.toLocaleDateString('en-US', opts);
+  return DATE_RANGE_FMT.formatRange(start, new Date(dateEnd + 'T12:00:00'));
 }
 
 function countdown(date, expires) {
@@ -144,8 +139,8 @@ document.getElementById('results-bar').addEventListener('click', function(e) {
 });
 
 Promise.all([
-  fetch('../data/events.json').then(function(r) { return r.json(); }),
-  fetch('../data/event-categories.json').then(function(r) { return r.json(); })
+  fetch('/data/events.json').then(function(r) { return r.json(); }),
+  fetch('/data/event-categories.json').then(function(r) { return r.json(); })
 ]).then(function(results) {
   events = results[0];
   categories = ['All'].concat(results[1]);

--- a/events/index.html
+++ b/events/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#0f172a">
   <meta name="description" content="The best events, hackathons, and conferences worth a student's time — curated, not aggregated.">
-  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
   <title>Events · Student Benefits Hub</title>
   <link rel="stylesheet" href="/assets/shared.css">
   <link rel="stylesheet" href="/events/events.css">


### PR DESCRIPTION
## Summary

Scoped down from the audit's original "front-end dedup" finding (I) after independently verifying its premises — most didn't hold up under a direct diff.

**Skipped, with reasons:**
- The 8 "shared" CSS selectors the audit found duplicated across `benefits/index.css` and `events.css` are **not** byte-identical — every one has different values per page. Hoisting any would mean picking one page's values to win, silently changing the other's appearance.
- The HTML "duplication" has real per-page differences interleaved throughout (different `h1` order, meta tags, search box on one page only) — cleanly separating it needs a templating/build step, which contradicts this project's explicit "no compile step" static-site design.
- `.free-toggle`/`.remote-toggle` and the two `::before` overlay rules are either not truly identical or trivially small (4 lines) — poor effort-to-value ratio.

**What was genuinely safe and valuable:**
- `fmtDate()` in `events.js` replaced with `Intl.DateTimeFormat.prototype.formatRange()` — this is a **real bug fix**: the custom version omitted the year on the start date for cross-year ranges (e.g. "Jul 1 – Jun 30, 2027", ambiguous). 4 live events have cross-year ranges and were all affected. Verified: now renders "Jul 1, 2026 – Jun 30, 2027".
- `benefits/index.js`: removed the runtime `<style>` injection + CSS attribute-selector mechanism for badge colors (with a hand-rolled escape the audit flagged) in favor of plain inline `style="color:..."`, matching the pattern `events.js` already uses.
- Standardized the 2 real absolute/relative path inconsistencies (favicon href, data fetch path) onto absolute paths, matching the convention already used everywhere else.

## Test plan
- [x] All 3 pages (`benefits/`, `events/`, `agent/`) loaded locally after every change — correct rendering, zero console errors
- [x] Verified the cross-year date fix against real data
- [x] Verified category badge colors still render correctly after the inline-style switch