### PR TITLE
Accessibility conformance fixes (audit finding J)

### DIFF
--- a/agent/agent.css
+++ b/agent/agent.css
@@ -59,6 +59,23 @@
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  z-index: 100;
+  padding: 0.75rem 1.25rem;
+  background: var(--grant-color);
+  color: var(--surface);
+  font-weight: 600;
+  border-radius: var(--radius-lg);
+  text-decoration: none;
+  transition: top var(--dur-fast);
+}
+.skip-link:focus {
+  top: 1rem;
+}
+
 body {
   font-family: var(--font);
   background: var(--bg);

--- a/agent/index.html
+++ b/agent/index.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<a href="#main-content" class="skip-link">Skip to content</a>
+
 <header class="site-header">
   <div class="header-inner">
     <a href="/" class="back-link">
@@ -21,7 +23,7 @@
   </div>
 </header>
 
-<main class="main">
+<main class="main" id="main-content">
 
   <!-- ── identity ─────────────────────────────────────── -->
   <section class="identity">

--- a/assets/shared.css
+++ b/assets/shared.css
@@ -39,6 +39,35 @@ body {
   outline-offset: 2px;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  z-index: 100;
+  padding: 0.75rem 1.25rem;
+  background: var(--indigo-400);
+  color: var(--slate-900);
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition: top var(--dur-normal);
+}
+.skip-link:focus {
+  top: 1rem;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;

--- a/assets/shared.js
+++ b/assets/shared.js
@@ -14,6 +14,28 @@ function hashColor(name, palette) {
   return palette[h % palette.length];
 }
 
+// Runs `renderFn` (an innerHTML-replacing render), then restores keyboard
+// focus to the equivalent new element if the focus was inside `container`
+// beforehand — an innerHTML swap destroys the focused node outright, which
+// otherwise drops a keyboard user back to the start of the page on every
+// filter click, toggle, or sort change.
+function withFocusPreserved(container, renderFn) {
+  var active = document.activeElement;
+  var selector = null;
+  if (active && container.contains(active)) {
+    if (active.id) {
+      selector = '#' + CSS.escape(active.id);
+    } else if (active.dataset && active.dataset.cat !== undefined) {
+      selector = '[data-cat="' + CSS.escape(active.dataset.cat) + '"]';
+    }
+  }
+  renderFn();
+  if (selector) {
+    var el = container.querySelector(selector);
+    if (el) el.focus();
+  }
+}
+
 // Renders filter tab buttons into `container`.
 // `categories` is an array of category strings.
 // `activeCategory` is the currently selected value.

--- a/benefits/index.html
+++ b/benefits/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/benefits/index.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <div class="page">
     <div class="container">
       <header>
@@ -46,16 +47,18 @@
         </div>
       </header>
 
-      <div id="results-bar" class="results-bar"></div>
+      <main id="main-content">
+        <div id="results-bar" class="results-bar" aria-live="polite" aria-atomic="true"></div>
 
-      <div id="content">
-        <div class="skeleton">
-          <div class="skeleton-card"></div>
-          <div class="skeleton-card"></div>
-          <div class="skeleton-card"></div>
-          <div class="skeleton-card"></div>
+        <div id="content">
+          <div class="skeleton">
+            <div class="skeleton-card"></div>
+            <div class="skeleton-card"></div>
+            <div class="skeleton-card"></div>
+            <div class="skeleton-card"></div>
+          </div>
         </div>
-      </div>
+      </main>
 
       <footer><a href="https://neves.cloud" target="_blank" rel="noopener">neves.cloud</a></footer>
     </div>

--- a/benefits/index.js
+++ b/benefits/index.js
@@ -30,7 +30,9 @@ function getFilteredAndSorted() {
 }
 
 function renderFilters() {
-  renderFilterTabs(filterBar, categories, activeCategory);
+  withFocusPreserved(filterBar, function () {
+    renderFilterTabs(filterBar, categories, activeCategory);
+  });
 }
 
 function renderCard(b) {
@@ -47,7 +49,7 @@ function renderCard(b) {
           <span class="badge" data-cat="${escapeHtml(b.category)}">${escapeHtml(b.category)}</span>
           ${pill}
         </div>
-        <h3 class="card-name">${escapeHtml(b.name)}</h3>
+        <h2 class="card-name">${escapeHtml(b.name)}</h2>
         <p class="card-desc">${escapeHtml(b.description)}</p>
       </a>
       <div class="tags">${tags}</div>
@@ -85,7 +87,7 @@ function renderGrid(filtered) {
 
 function render() {
   const filtered = getFilteredAndSorted();
-  renderResultsBar(filtered);
+  withFocusPreserved(resultsBar, function () { renderResultsBar(filtered); });
   renderGrid(filtered);
 }
 
@@ -106,6 +108,7 @@ resultsBar.addEventListener('click', function (e) {
     searchQuery = '';
     searchInput.value = '';
     render();
+    searchInput.focus(); // the clear button itself no longer exists post-render
   }
 });
 
@@ -123,7 +126,7 @@ searchInput.addEventListener('input', function () {
 });
 
 document.addEventListener('keydown', function (e) {
-  if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+  if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLSelectElement) return;
   if (e.metaKey || e.ctrlKey || e.altKey) return;
   if (e.key.length === 1 && /[a-zA-Z0-9]/.test(e.key)) {
     searchInput.focus();
@@ -136,6 +139,7 @@ content.addEventListener('click', function (e) {
   searchQuery = tag.dataset.tag;
   searchInput.value = searchQuery;
   render();
+  searchInput.focus(); // the clicked tag itself no longer exists post-render
 });
 
 // Excludes offer-type colors (#a78bfa trial, #60a5fa credits, #fbbf24 discount, #4ade80 free)

--- a/events/events.js
+++ b/events/events.js
@@ -44,16 +44,16 @@ function countdown(date, expires) {
     if (expires) {
       const end = new Date(expires + 'T00:00:00');
       const left = Math.round((end - now) / 86400000);
-      if (left === 0) return { text: 'Ends today', cls: 'event-countdown--soon' };
-      if (left === 1) return { text: 'Ends tomorrow', cls: 'event-countdown--soon' };
-      if (left <= 14) return { text: 'Ends in ' + left + ' days', cls: 'event-countdown--soon' };
+      if (left === 0) return { text: 'Ends today', cls: 'event-countdown--soon', urgent: true };
+      if (left === 1) return { text: 'Ends tomorrow', cls: 'event-countdown--soon', urgent: true };
+      if (left <= 14) return { text: 'Ends in ' + left + ' days', cls: 'event-countdown--soon', urgent: true };
     }
-    return { text: 'Ongoing', cls: 'event-countdown--upcoming' };
+    return { text: 'Ongoing', cls: 'event-countdown--upcoming', urgent: false };
   }
-  if (days === 0) return { text: 'Today', cls: 'event-countdown--soon' };
-  if (days === 1) return { text: 'Tomorrow', cls: 'event-countdown--soon' };
-  if (days <= 14) return { text: days + ' days away', cls: 'event-countdown--soon' };
-  return { text: days + ' days away', cls: 'event-countdown--upcoming' };
+  if (days === 0) return { text: 'Today', cls: 'event-countdown--soon', urgent: true };
+  if (days === 1) return { text: 'Tomorrow', cls: 'event-countdown--soon', urgent: true };
+  if (days <= 14) return { text: days + ' days away', cls: 'event-countdown--soon', urgent: true };
+  return { text: days + ' days away', cls: 'event-countdown--upcoming', urgent: false };
 }
 
 function isExpired(e) {
@@ -85,7 +85,7 @@ function renderCard(e) {
         <span class="event-cat">${escapeHtml(e.category)}</span>
         ${locationPill}
       </div>
-      <h3 class="event-name">${escapeHtml(e.name)}</h3>
+      <h2 class="event-name">${escapeHtml(e.name)}</h2>
       <div class="event-meta">
         <span class="event-meta-line">
           <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
@@ -99,7 +99,7 @@ function renderCard(e) {
       <p class="event-why">${escapeHtml(e.why)}</p>
     </a>
     <div class="event-footer">
-      <span class="event-countdown ${escapeHtml(cd.cls)}">${escapeHtml(cd.text)}</span>
+      <span class="event-countdown ${escapeHtml(cd.cls)}">${cd.urgent ? '<span class="sr-only">Time-sensitive: </span>' : ''}${escapeHtml(cd.text)}</span>
       <a class="event-apply" href="${escapeHtml(e.link)}" target="_blank" rel="noopener noreferrer">
         Apply
         <svg width="10" height="10" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M14 5l7 7m0 0l-7 7m7-7H3"/></svg>
@@ -112,10 +112,12 @@ function renderFilters() {
   const filterBar = document.getElementById('filter-bar');
   const usedCats = new Set(events.filter(function(e) { return !isExpired(e); }).map(function(e) { return e.category; }));
   const visibleCategories = categories.filter(function(c) { return c === 'All' || usedCats.has(c); });
-  renderFilterTabs(filterBar, visibleCategories, activeCategory, function(c) {
-    return c === 'All' ? 'All' : c.charAt(0).toUpperCase() + c.slice(1);
-  }, function(c) {
-    return categoryTooltips[c] || '';
+  withFocusPreserved(filterBar, function () {
+    renderFilterTabs(filterBar, visibleCategories, activeCategory, function(c) {
+      return c === 'All' ? 'All' : c.charAt(0).toUpperCase() + c.slice(1);
+    }, function(c) {
+      return categoryTooltips[c] || '';
+    });
   });
 }
 
@@ -124,8 +126,10 @@ function render() {
   const resultsBar = document.getElementById('results-bar');
   const content = document.getElementById('content');
   const label = filtered.length === 1 ? 'event' : 'events';
-  resultsBar.innerHTML = `<span class="results-count"><strong>${filtered.length}</strong> upcoming ${label}</span>` +
-    `<button class="remote-toggle" aria-pressed="${remoteOnly}">Remote only</button>`;
+  withFocusPreserved(resultsBar, function () {
+    resultsBar.innerHTML = `<span class="results-count"><strong>${filtered.length}</strong> upcoming ${label}</span>` +
+      `<button class="remote-toggle" id="remote-toggle" aria-pressed="${remoteOnly}">Remote only</button>`;
+  });
 
   if (filtered.length > 0) {
     content.innerHTML = `<div class="grid">${filtered.map(renderCard).join('')}</div>`;

--- a/events/index.html
+++ b/events/index.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="/events/events.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <div class="page">
     <div class="container">
 
@@ -35,21 +36,23 @@
           </div>
         </div>
         <p class="subtitle">Hackathons, grants, fellowships, and conferences — curated, not aggregated.</p>
+
+        <div class="filter-wrap">
+          <div id="filter-bar" class="filter-bar" role="group" aria-label="Filter events"></div>
+        </div>
       </header>
 
-      <div class="filter-wrap">
-        <div id="filter-bar" class="filter-bar" role="group" aria-label="Filter events"></div>
-      </div>
+      <main id="main-content">
+        <div id="results-bar" class="results-bar" aria-live="polite" aria-atomic="true"></div>
 
-      <div id="results-bar" class="results-bar"></div>
-
-      <div id="content">
-        <div class="skeleton">
-          <div class="skeleton-card"></div>
-          <div class="skeleton-card"></div>
-          <div class="skeleton-card"></div>
+        <div id="content">
+          <div class="skeleton">
+            <div class="skeleton-card"></div>
+            <div class="skeleton-card"></div>
+            <div class="skeleton-card"></div>
+          </div>
         </div>
-      </div>
+      </main>
 
       <footer><a href="https://neves.cloud" target="_blank" rel="noopener">neves.cloud</a></footer>
     </div>


### PR DESCRIPTION
## Summary

Audit finding J. Six of seven findings fixed, one deferred with reasoning.

**Focus loss on every filter/toggle interaction** — `renderFilterTabs` and results-bar controls fully replace their container's innerHTML on every interaction, destroying the just-clicked element. Added `withFocusPreserved()` to `shared.js`, wired into both pages. `clear-btn`/tag clicks (whose target doesn't exist post-render by design) move focus to the search input instead.

**No live region** — added `aria-live="polite" aria-atomic="true"` to `#results-bar` on both pages.

**Type-to-search stealing focus from the sort `<select>`** — added the missing `HTMLSelectElement` guard.

**No `<main>` landmark or skip link** — added both to `benefits/` and `events/`. `agent/index.html` already had a `<main>` (the audit's claim otherwise was wrong there) — added a matching skip link only.

**h1 → h3 heading skip** — `card-name`/`event-name` changed h3 → h2 (h2 was entirely unused).

**Color-only urgency encoding** — `countdown()` returned identical text for both urgency classes. Added an `urgent` flag + visually-hidden "Time-sensitive: " prefix (new `.sr-only` utility) so screen reader users get the same distinction sighted users get from color.

**Deferred**: category-explanation tooltips (`title=`) still aren't reachable by keyboard/touch. A correct accessible tooltip is a real UI component (positioning, dismiss-on-escape), not a cleanup-scope fix, and these are supplementary rather than required info.

## Testing note

Focus-preservation and live-region wiring were verified directly (`activeElement` checks, CSSOM/attribute inspection) rather than via simulated Tab-key screenshots — this session's browser automation layer doesn't reliably trigger native focus-navigation via synthetic key events (`.focus()` correctly moves `document.activeElement`, but real Tab keypresses via the automation tool didn't advance focus — a CDP-level limitation, not a property of the shipped code). Verified everything checkable through direct inspection instead.

## Test plan
- [x] Filter-tab click: focus lands on the equivalent new button (verified via `activeElement`)
- [x] free-toggle/remote-toggle click: focus preserved on the same control
- [x] clear-btn / tag click: focus correctly falls back to search input
- [x] `aria-live`/`aria-atomic` present and correct on both pages
- [x] Skip link is the first focusable element in DOM order on all 3 pages, target exists
- [x] `sr-only` urgency text present, visually hidden (1x1px), correct content
- [x] Heading counts: 1 h1, N h2 (cards), 0 h3 on both pages
- [x] Zero console errors on all 3 pages