### PR TITLE
Small cleanups: model repo variable, composite gate action, labels, meta tag

### DIFF
--- a/.github/actions/biweekly-gate/action.yml
+++ b/.github/actions/biweekly-gate/action.yml
@@ -1,0 +1,25 @@
+name: Biweekly cadence gate
+description: >
+  Skips a scheduled run on odd ISO weeks so the calling workflow effectively
+  runs every other week; any other trigger (workflow_dispatch, etc.) always
+  proceeds. Cron itself can't express "every 2 weeks", so this is the
+  standard workaround: keep the weekly cron trigger, gate the actual work.
+
+outputs:
+  should-run:
+    description: "'true' if the calling workflow should proceed"
+    value: ${{ steps.check.outputs.run }}
+
+runs:
+  using: composite
+  steps:
+    - id: check
+      shell: bash
+      run: |
+        week=$(date -u +%V)
+        if [ "${{ github.event_name }}" != "schedule" ] || [ $((10#$week % 2)) -eq 0 ]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "run=false" >> "$GITHUB_OUTPUT"
+          echo "Skipping — ISO week $week is odd, this workflow runs biweekly on even weeks"
+        fi

--- a/.github/workflows/add-benefit.yml
+++ b/.github/workflows/add-benefit.yml
@@ -31,7 +31,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
           allowed_bots: "claude"
-          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
+          claude_args: "--model ${{ vars.CLAUDE_MODEL }} --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
           prompt: |
             You process student benefit submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it, and either open a PR adding the benefit or comment explaining why it can't be added.
 

--- a/.github/workflows/add-event.yml
+++ b/.github/workflows/add-event.yml
@@ -31,7 +31,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
           allowed_bots: "claude"
-          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
+          claude_args: "--model ${{ vars.CLAUDE_MODEL }} --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
           prompt: |
             You process student event submissions from GitHub issues. Read issue #${{ github.event.issue.number || github.event.inputs.issue }}, validate it against the quality bar, and either open a PR adding the event or comment explaining why it can't be added.
 

--- a/.github/workflows/discover-benefits.yml
+++ b/.github/workflows/discover-benefits.yml
@@ -27,27 +27,19 @@ jobs:
       id-token: write
 
     steps:
-      - name: Check cadence (biweekly — even ISO weeks only; manual runs always proceed)
-        id: cadence
-        run: |
-          week=$(date -u +%V)
-          if [ "${{ github.event_name }}" != "schedule" ] || [ $((10#$week % 2)) -eq 0 ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping — ISO week $week is odd, this workflow runs biweekly on even weeks"
-          fi
-
       - uses: actions/checkout@v4
-        if: steps.cadence.outputs.run == 'true'
         with:
           fetch-depth: 1
 
+      - name: Check cadence (biweekly — even ISO weeks only; manual runs always proceed)
+        id: cadence
+        uses: ./.github/actions/biweekly-gate
+
       - uses: anthropics/claude-code-action@v1
-        if: steps.cadence.outputs.run == 'true'
+        if: steps.cadence.outputs.should-run == 'true'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
+          claude_args: "--model ${{ vars.CLAUDE_MODEL }} --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*)'"
           prompt: |
             You proactively discover student benefits not yet in the directory and open GitHub issues for the best finds. The add-benefit workflow will pick them up.
 

--- a/.github/workflows/discover-events.yml
+++ b/.github/workflows/discover-events.yml
@@ -27,27 +27,19 @@ jobs:
       id-token: write
 
     steps:
-      - name: Check cadence (biweekly — even ISO weeks only; manual runs always proceed)
-        id: cadence
-        run: |
-          week=$(date -u +%V)
-          if [ "${{ github.event_name }}" != "schedule" ] || [ $((10#$week % 2)) -eq 0 ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping — ISO week $week is odd, this workflow runs biweekly on even weeks"
-          fi
-
       - uses: actions/checkout@v4
-        if: steps.cadence.outputs.run == 'true'
         with:
           fetch-depth: 1
 
+      - name: Check cadence (biweekly — even ISO weeks only; manual runs always proceed)
+        id: cadence
+        uses: ./.github/actions/biweekly-gate
+
       - uses: anthropics/claude-code-action@v1
-        if: steps.cadence.outputs.run == 'true'
+        if: steps.cadence.outputs.should-run == 'true'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
+          claude_args: "--model ${{ vars.CLAUDE_MODEL }} --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
           prompt: |
             You discover student events worth a student's time, remove expired entries, and open one PR with both. Today's date is needed in UTC ISO 8601 — derive it.
 

--- a/.github/workflows/maintain-benefits.yml
+++ b/.github/workflows/maintain-benefits.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-6 --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
+          claude_args: "--model ${{ vars.CLAUDE_MODEL }} --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,WebSearch,WebFetch,Bash(git:*),Bash(gh:*),Bash(python3 scripts/validate_data.py)'"
           prompt: |
             You audit every entry in `data/benefits.json`, fix what you can, validate, and open a single PR. Findings go to the PR — never open issues.
 

--- a/benefits/index.html
+++ b/benefits/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#0f172a">
+  <meta name="description" content="Free and discounted dev tools, cloud credits, AI/ML platforms, and design resources for students — curated, not aggregated.">
   <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
   <title>Student Benefits Hub</title>
   <link rel="stylesheet" href="/assets/shared.css">


### PR DESCRIPTION
## Summary

Audit's lower-priority findings.

- Created repo variable `CLAUDE_MODEL` (`claude-sonnet-4-6`) and pointed all 5 `claude_args --model` references at it. `agent/index.html`'s doc mention stays a manually-synced mirror — static HTML with no build step can't read a CI-only variable, so unifying it further would need a build step this project deliberately doesn't have.
- Extracted the byte-identical biweekly ISO-week gate (duplicated in `discover-benefits.yml`/`discover-events.yml`) into a composite action, `.github/actions/biweekly-gate`. **Fixed a real ordering bug in the process**: local composite actions need the repo already checked out, but the original inline version ran before `actions/checkout`. Moved checkout first (cheap) and gated only the expensive `claude-code-action` step on cadence.
- `link-health`/`needs-review` labels were grey with empty descriptions, unlike every other label in the repo. Set color + description on both.
- `benefits/index.html` was the only page missing a `<meta name="description">` despite being the landing page.

## Test plan
- [x] All workflow + composite action YAML validated for syntax
- [x] Confirmed no stale references to the old `steps.cadence.outputs.run` output name remain after the composite-action rename to `should-run`
- [x] `benefits/index.html` parses correctly
- [ ] Full live verification of the composite action happens on the next scheduled/manual discover-benefits or discover-events run (didn't want to spend real API cost/create real issues just to test step ordering — the checkout-before-local-action pattern is standard)